### PR TITLE
Update handbook links and fix broken links

### DIFF
--- a/website/doc/index.md
+++ b/website/doc/index.md
@@ -23,31 +23,31 @@ hero:
 features:
   - title: 100% Typescript
     details: typescript based and with typescript in mind and mostly async-await (no call-back hell)
-    link: /handbook/1._get-started/1_purista_cli
+    link: /handbook/1_quickstart/setup-the-purista-project
     icon: 🛠️
 
   - title: K.I.S.S
     details: simply just implement your logic without overhead
-    link: /handbook/1._get-started/0_concept
+    link: /handbook/concept
     icon: 💋
 
   - title: Modular & extendable
     details: adding new functions and services is simple, fast and isolated
-    link: /handbook/1._get-started/0_concept
+    link: /handbook/concept
     icon: 📦
 
   - title: Scales
     details: runs and scales from small single instance up to cloud clusters and cloud functions.
-    link: /handbook/6._scale/0_scale
+    link: /handbook/5_deploy_and_scale/monolithic
     icon: 📈
 
   - title: Compliance & Monitoring
     details: flexible to trace, audit and monitor and to get a clear picture of what's going on
-    link: /handbook/5._tracing/0_opentelemetry
+    link: /handbook/4_open_telemetry/
     icon: 🕵️
 
   - title: Easy to test
     details: "easy to test with ready to go mocks & stubs which increases productivity and reduces costs"
-    link: /handbook/2._start-building/2.2_command/2_test-a-command
+    link: /handbook/2_building_business-logic/command/test-a-command
     icon: ✅
 ---


### PR DESCRIPTION
This pull request updates the handbook links in the doc index to fix broken links. It also updates the links in the features section to point to the correct locations in the handbook.