### PR TITLE
ci: align workflows with main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ name: 'CodeQL'
 on:
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '35 21 * * 0'
 

--- a/.github/workflows/pull_resquest.yml
+++ b/.github/workflows/pull_resquest.yml
@@ -2,7 +2,7 @@ name: Pull request
 
 on:
   pull_request:
-    branches: ['master']
+    branches: ['main']
 
 jobs:
   # Build job

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -16,10 +16,10 @@ jobs:
     environment: publish_version
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure workflow runs on master
-        if: github.ref != 'refs/heads/master'
+      - name: Ensure workflow runs on main
+        if: github.ref != 'refs/heads/main'
         run: |
-          echo "Release publish must run on master. Current ref: ${{ github.ref }}"
+          echo "Release publish must run on main. Current ref: ${{ github.ref }}"
           exit 1
 
       - name: Checkout

--- a/.github/workflows/release_version.yml
+++ b/.github/workflows/release_version.yml
@@ -78,8 +78,8 @@ jobs:
         run: |
           RELEASE_BRANCH="${{ steps.commit.outputs.branch }}"
           VERSION="${{ steps.version.outputs.value }}"
-          COMPARE_URL="https://github.com/${{ github.repository }}/compare/master...$RELEASE_BRANCH?expand=1"
-          PR_NUMBER="$(gh pr list --head "$RELEASE_BRANCH" --base master --json number --jq '.[0].number' || true)"
+          COMPARE_URL="https://github.com/${{ github.repository }}/compare/main...$RELEASE_BRANCH?expand=1"
+          PR_NUMBER="$(gh pr list --head "$RELEASE_BRANCH" --base main --json number --jq '.[0].number' || true)"
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             if ! gh pr edit "$PR_NUMBER" \
               --title "chore(release): v$VERSION" \
@@ -89,7 +89,7 @@ jobs:
             fi
           else
             if ! gh pr create \
-              --base master \
+              --base main \
               --head "$RELEASE_BRANCH" \
               --title "chore(release): v$VERSION" \
               --body "Automated release preparation PR for v$VERSION."; then


### PR DESCRIPTION
Align CI and release workflows with the renamed default branch: main.

Also updated the GitHub environment branch policies for publish_version and github-pages from master to main, because those settings live outside the repo.