### PR TITLE
[codex] Fix production website landing layout

### DIFF
--- a/web/src/layouts/DocPageLayout.astro
+++ b/web/src/layouts/DocPageLayout.astro
@@ -1,7 +1,7 @@
 ---
-import '../styles/site.css'
 import Nav from '../components/landing/Nav.astro'
 import BaseLayout from './BaseLayout.astro'
+import '../styles/site.css'
 
 interface Props {
 	title: string

--- a/web/src/layouts/HandbookLayout.astro
+++ b/web/src/layouts/HandbookLayout.astro
@@ -1,8 +1,8 @@
 ---
-import '../styles/site.css'
 import Nav from '../components/landing/Nav.astro'
 import type { SidebarItem } from '../lib/sidebar'
 import BaseLayout from './BaseLayout.astro'
+import '../styles/site.css'
 
 interface Props {
 	title: string

--- a/web/src/layouts/SiteLayout.astro
+++ b/web/src/layouts/SiteLayout.astro
@@ -1,10 +1,10 @@
 ---
-import '../styles/site.css'
 import HarnessNav from '../components/ui/HarnessNav.astro'
 import Footer from '../components/landing/Footer.astro'
 import Nav from '../components/landing/Nav.astro'
 import type { PrimaryNavKey } from '../data/navigation'
 import BaseLayout from './BaseLayout.astro'
+import '../styles/site.css'
 
 interface Props {
 	title?: string

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -7,7 +7,7 @@ import PathSelector from '../components/landing/PathSelector.astro'
 import SectionIntro from '../components/landing/SectionIntro.astro'
 import HomePillars from '../components/landing/sections/HomePillars.astro'
 import EnterpriseAnatomy from '../components/landing/visualizations/EnterpriseAnatomy.astro'
-import HarnessLayout from '../layouts/HarnessLayout.astro'
+import SiteLayout from '../layouts/SiteLayout.astro'
 
 /**
  * Home — TRIAGE HUB.
@@ -23,7 +23,7 @@ import HarnessLayout from '../layouts/HarnessLayout.astro'
 
 ---
 
-<HarnessLayout
+<SiteLayout
   title="PURISTA — Enterprise TypeScript backends. Provider-agnostic. Traceable. Approval-ready."
   description="Open-source TypeScript framework for enterprise backends. Provider-agnostic by construction. Traceable and auditable end-to-end. Approval-ready by structure."
   active="home"
@@ -200,7 +200,7 @@ import HarnessLayout from '../layouts/HarnessLayout.astro'
     ]}
   />
 
-</HarnessLayout>
+</SiteLayout>
 
 <style>
   .site-concept-grid {
@@ -264,4 +264,3 @@ import HarnessLayout from '../layouts/HarnessLayout.astro'
     color: var(--color-fg-muted);
   }
 </style>
-

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -11,6 +11,73 @@
    THEME TOKENS
    ======================================== */
 
+:root {
+	/* --- Light Mode (Default) --- */
+	--color-bg: #fafafa;
+	--color-bg-elev: #ffffff;
+	--color-bg-sunk: #f2f2f4;
+	--color-bg-deep: #e8e8ec;
+
+	--color-fg: #08080b;
+	--color-fg-strong: #000000;
+	--color-fg-muted: #4d4d55;
+	--color-fg-subtle: #8b8b92;
+
+	--color-line: rgba(8, 8, 11, 0.08);
+	--color-line-strong: rgba(8, 8, 11, 0.16);
+	--color-line-vivid: rgba(8, 8, 11, 0.28);
+
+	/* Semantic accent colors */
+	--color-pilot: #059669;
+	--color-pilot-hi: #10b981;
+	--color-pilot-glow: rgba(16, 185, 129, 0.18);
+
+	--color-con: #7c3aed;
+	--color-con-hi: #a855f7;
+	--color-con-glow: rgba(168, 85, 247, 0.18);
+
+	--color-found: #2563eb;
+	--color-found-hi: #60a5fa;
+	--color-found-glow: rgba(96, 165, 250, 0.18);
+
+	/* Code blocks */
+	--color-code-bg: #f2f2f5;
+	--color-code-fg: #1a1a1e;
+	--color-code-line: rgba(8, 8, 11, 0.06);
+
+	/* Typography */
+	--font-sans: "Inter", system-ui, -apple-system, sans-serif;
+	--font-display: "Inter Tight", system-ui, -apple-system, sans-serif;
+	--font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+
+	/* Layout */
+	--layout-max-fluid: 1680px;
+	--layout-max-wide: 1440px;
+	--layout-max-page: 1280px;
+	--layout-max-story: 1240px;
+	--layout-max-copy: 960px;
+	--max-width: var(--layout-max-fluid);
+	--gutter: clamp(1.25rem, 4vw, 3rem);
+
+	/* Radius */
+	--radius-sm: 8px;
+	--radius-md: 12px;
+	--radius-lg: 16px;
+	--radius-xl: 20px;
+	--radius-2xl: 24px;
+
+	/* Transitions */
+	--transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	--transition-base: 250ms cubic-bezier(0.4, 0, 0.2, 1);
+	--transition-slow: 400ms cubic-bezier(0.4, 0, 0.2, 1);
+	--transition-bounce: 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+
+	/* Shadows */
+	--shadow-sm: 0 1px 2px rgba(8, 8, 11, 0.04);
+	--shadow-md: 0 12px 28px -10px rgba(8, 8, 11, 0.1), 0 3px 8px rgba(8, 8, 11, 0.04);
+	--shadow-lg: 0 32px 80px -24px rgba(8, 8, 11, 0.18), 0 12px 28px -12px rgba(8, 8, 11, 0.08);
+}
+
 @theme {
 	/* --- Light Mode (Default) --- */
 	--color-bg: #fafafa;


### PR DESCRIPTION
## Summary
- switch the homepage back from HarnessLayout to SiteLayout
- emit design tokens as runtime :root CSS variables so site layout variables exist in production
- reorder site.css imports after BaseLayout so Tailwind/global layer order does not override site component typography

## Root cause
The deployed home page was using the harness shell and the built CSS did not expose required runtime layout tokens. Site component CSS was also emitted before global/Tailwind CSS, allowing base layer rules to flatten the hero typography.

## Verification
- fnm exec --using 24.15.0 npm run build -w @purista/web
- fnm exec --using 24.15.0 npm run lint
- git diff --check
- verified production preview at http://127.0.0.1:4329/ with Playwright desktop and mobile screenshots
- Playwright console: 0 errors, only existing deprecated apple mobile web app meta warning