### PR TITLE
[codex] add queue worker capability declarations

### DIFF
--- a/examples/agent-example/package.json
+++ b/examples/agent-example/package.json
@@ -23,16 +23,16 @@
 	},
 	"devDependencies": {
 		"@types/node": "^25.9.1",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",
 		"@purista/core": "*",
 		"@purista/harness-openai": "^1.1.0",
 		"@purista/hono-http-server": "*",
-		"@scalar/hono-api-reference": "^0.10.19",
+		"@scalar/hono-api-reference": "^0.10.20",
 		"dotenv": "^17.4.2",
 		"zod": "^4.4.3"
 	}

--- a/examples/client-builder/package.json
+++ b/examples/client-builder/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@purista/core": "*",
 		"@hono/node-server": "^2.0.4",
-		"@scalar/hono-api-reference": "^0.10.19",
+		"@scalar/hono-api-reference": "^0.10.20",
 		"@purista/hono-http-server": "*"
 	},
 	"devDependencies": {
@@ -33,8 +33,8 @@
 		"typescript": "^6.0.3",
 		"sinon": "^22.0.0",
 		"@biomejs/biome": "^2.4.16",
-		"tsx": "^4.22.3",
-		"vitest": "^4.1.7"
+		"tsx": "^4.22.4",
+		"vitest": "^4.1.8"
 	},
 	"trustedDependencies": [
 		"@biomejs/biome"

--- a/examples/dapr-example/package.json
+++ b/examples/dapr-example/package.json
@@ -24,9 +24,9 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/enterprise-billing-cycle/package.json
+++ b/examples/enterprise-billing-cycle/package.json
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^25.9.1",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {

--- a/examples/fullexample/package.json
+++ b/examples/fullexample/package.json
@@ -41,9 +41,9 @@
 	"devDependencies": {
 		"@types/node": "^25.9.1",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/hono-example/package.json
+++ b/examples/hono-example/package.json
@@ -25,15 +25,15 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/sdk-metrics": "^2.7.1",
-		"@scalar/hono-api-reference": "^0.10.19",
+		"@scalar/hono-api-reference": "^0.10.20",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
 		"zod": "^4.4.3"

--- a/examples/kubernetes/package.json
+++ b/examples/kubernetes/package.json
@@ -24,9 +24,9 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/metrics/package.json
+++ b/examples/metrics/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^25.9.1",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {

--- a/examples/mqtt-bridge/package.json
+++ b/examples/mqtt-bridge/package.json
@@ -26,9 +26,9 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/nats-bridge/package.json
+++ b/examples/nats-bridge/package.json
@@ -26,9 +26,9 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -24,9 +24,9 @@
 		"@types/node": "^25.9.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@hono/node-server": "^2.0.4",

--- a/examples/temporal/package.json
+++ b/examples/temporal/package.json
@@ -39,8 +39,8 @@
 		"@types/sinon": "^21.0.1",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@biomejs/biome": "^2.4.16",
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
-				"@vitest/coverage-v8": "^4.1.7",
+				"@vitest/coverage-v8": "^4.1.8",
 				"check-dependency-version-consistency": "^6.0.0",
 				"git-cliff": "^2.13.1",
 				"npm-check-updates": "^22.2.1",
@@ -23,10 +23,10 @@
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.1",
 				"ts-node": "^10.9.2",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typedoc": "^0.28.19",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -41,15 +41,15 @@
 				"@purista/core": "*",
 				"@purista/harness-openai": "^1.1.0",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.10.19",
+				"@scalar/hono-api-reference": "^0.10.20",
 				"dotenv": "^17.4.2",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@types/node": "^25.9.1",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -61,7 +61,7 @@
 				"@hono/node-server": "^2.0.4",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.10.19"
+				"@scalar/hono-api-reference": "^0.10.20"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.16",
@@ -70,9 +70,9 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -94,9 +94,9 @@
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -112,7 +112,7 @@
 			},
 			"devDependencies": {
 				"@types/node": "^25.9.1",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3"
 			},
 			"engines": {
@@ -142,9 +142,9 @@
 			"devDependencies": {
 				"@types/node": "^25.9.1",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -160,16 +160,16 @@
 				"@opentelemetry/sdk-metrics": "^2.7.1",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.10.19",
+				"@scalar/hono-api-reference": "^0.10.20",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -191,9 +191,9 @@
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -211,7 +211,7 @@
 			},
 			"devDependencies": {
 				"@types/node": "^25.9.1",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3"
 			},
 			"engines": {
@@ -233,9 +233,9 @@
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -257,9 +257,9 @@
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -279,9 +279,9 @@
 				"@types/node": "^25.9.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -312,197 +312,12 @@
 				"@types/sinon": "^21.0.1",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.22.3",
+				"tsx": "^4.22.4",
 				"typescript": "^6.0.3",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/resources": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/resources": "1.30.1",
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/common": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
-			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.17.2",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/interceptors-opentelemetry": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/interceptors-opentelemetry/-/interceptors-opentelemetry-1.17.2.tgz",
-			"integrity": "sha512-D2ZU/59dAC+b1rjLgVFhmwdJaIQUL+Sb/QhrZxv7eNzHgfc1/bon0kzGWIhdSr8FgEVZEMIhSx62JyLN9WXwIw==",
-			"license": "MIT",
-			"dependencies": {
-				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/core": "^1.25.1",
-				"@opentelemetry/resources": "^1.25.1",
-				"@opentelemetry/sdk-trace-base": "^1.25.1",
-				"@temporalio/plugin": "1.17.2"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			},
-			"peerDependencies": {
-				"@temporalio/common": "1.17.2",
-				"@temporalio/workflow": "1.17.2"
-			},
-			"peerDependenciesMeta": {
-				"@temporalio/workflow": {
-					"optional": true
-				}
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/plugin": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.17.2.tgz",
-			"integrity": "sha512-vBWHNf+0R3+yfb/LVQKWrzlXuwGWQjb88+5mfFCfGQaxyMeHzkQQBMNJ5NIoCLJsnwhs+1U93hldQ8j+fDL4yg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/proto": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
-			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.5.5"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/workflow": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.17.2.tgz",
-			"integrity": "sha512-eRnZfjfaL9gSmVCOk6zRCE9QKQSyLgnlhnOKMjeIqGJeZC8XAYA16A5HKv2Uf3UiE2EcqRhak+uRPZP9qnTrmQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/common": "1.17.2",
-				"@temporalio/proto": "1.17.2",
-				"nexus-rpc": "^0.0.2"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"examples/temporal/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
-		"examples/temporal/node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -624,14 +439,14 @@
 			}
 		},
 		"node_modules/@astrojs/react": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.6.tgz",
-			"integrity": "sha512-3pfjmw3sUnV5WplLblDzsAKlHv9kNmlCFAw/xP/agubiZFo4d+uPXX2jynNwAfvwyI5v+Q9uIIFwyujv9jifLg==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.7.tgz",
+			"integrity": "sha512-N9cCoxvnLWaP+AK1Fv4e5Mc7ktnVTpSo2nWLwvD9Ohr1dJKygwrTSm9yatqoahgb1A5Kwjg/rT2shRiIVdn3aw==",
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/internal-helpers": "0.10.0",
 				"@vitejs/plugin-react": "^5.2.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"ultrahtml": "^1.6.0",
 				"vite": "^7.3.2"
 			},
@@ -740,20 +555,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-secrets-manager": {
-			"version": "3.1056.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1056.0.tgz",
-			"integrity": "sha512-jqX/F5tA7k2yutSm2I6AFXaxK91DhDn+em5sWfmNsYBp8VEM2PwHCp5gUvzStQUhszrSAduHNCEdqxJtYiExCA==",
+			"version": "3.1060.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1060.0.tgz",
+			"integrity": "sha512-KsGmoA2GMsCD/5opZx12fGoZY8l9VlCDigeE4UWNDbEocrJfWF/hL9vzWiUm7M1bbov7lPwOG85oY7A9ibak3A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/credential-provider-node": "^3.972.46",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/fetch-http-handler": "^5.4.5",
-				"@smithy/node-http-handler": "^4.7.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/credential-provider-node": "^3.972.50",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -761,20 +576,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ssm": {
-			"version": "3.1056.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1056.0.tgz",
-			"integrity": "sha512-S367Brp+IyAc76US26MlOgYXvcMJMqKQi1gR4GcUI5K7NgG/f3AsICXV9Hg+KjqurSyyb8B2w8SgDJ20VT/bNg==",
+			"version": "3.1060.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1060.0.tgz",
+			"integrity": "sha512-+VpH992rnAWAdDGU0gMnzzKaWBvY2YkqS59QeN3/teK5LueOMEqTqRKAPP1uTYnICIe0DVTSNv8kmfT+5I592A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/credential-provider-node": "^3.972.46",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/fetch-http-handler": "^5.4.5",
-				"@smithy/node-http-handler": "^4.7.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/credential-provider-node": "^3.972.50",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -782,17 +597,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
-			"integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+			"version": "3.974.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.17.tgz",
+			"integrity": "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@aws-sdk/xml-builder": "^3.972.26",
+				"@aws-sdk/types": "^3.973.10",
+				"@aws-sdk/xml-builder": "^3.972.27",
 				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/core": "^3.24.5",
-				"@smithy/signature-v4": "^5.4.5",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -801,15 +616,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
-			"integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.43.tgz",
+			"integrity": "sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -817,17 +632,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
-			"integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+			"version": "3.972.45",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.45.tgz",
+			"integrity": "sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/fetch-http-handler": "^5.4.5",
-				"@smithy/node-http-handler": "^4.7.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -835,23 +650,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.45.tgz",
-			"integrity": "sha512-sJe5ZWibO4s7RWjFQ8Zol76KxoJcIYyEZH1/wxQSBMSIAAxzaJ8cS/ITAaIHWUQvDKQdt18+cJAHKWB7n1Jmrg==",
+			"version": "3.972.48",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.48.tgz",
+			"integrity": "sha512-+6BQ6Lrnc+EyAGElLRW6j+Sa+RirPHnIJsobvYO6nnyK+oGKmz1ne/ieclbLWyjyDKEU3/JVJWcWY3VLFPvGtQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/credential-provider-env": "^3.972.41",
-				"@aws-sdk/credential-provider-http": "^3.972.43",
-				"@aws-sdk/credential-provider-login": "^3.972.45",
-				"@aws-sdk/credential-provider-process": "^3.972.41",
-				"@aws-sdk/credential-provider-sso": "^3.972.45",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.45",
-				"@aws-sdk/nested-clients": "^3.997.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/credential-provider-imds": "^4.3.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/credential-provider-env": "^3.972.43",
+				"@aws-sdk/credential-provider-http": "^3.972.45",
+				"@aws-sdk/credential-provider-login": "^3.972.47",
+				"@aws-sdk/credential-provider-process": "^3.972.43",
+				"@aws-sdk/credential-provider-sso": "^3.972.47",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.47",
+				"@aws-sdk/nested-clients": "^3.997.15",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -859,16 +674,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
-			"integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+			"version": "3.972.47",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.47.tgz",
+			"integrity": "sha512-Iy2ebWVgrZBH05464uJiQYu6HSSiROnwVZptthEFXx2gWjo1ORCxEAFZB5Cr2MdfrSnZ+0QUPkZ1ZpCqpkUrLQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/nested-clients": "^3.997.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/nested-clients": "^3.997.15",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -876,21 +691,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.46",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.46.tgz",
-			"integrity": "sha512-cS4w0jzDRb1jOlkiJS3y80OxddHzkky/MN9k3NYs5jganNKVLjF0lpvjlwS118oGMr3cdAfOlVdo8gLurTSE7w==",
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.50.tgz",
+			"integrity": "sha512-b05Aelq5cqAvCCDQjCYacl0XmR8QhBNSqLbsdISkQmlQBa5oPS66zYPteWcSp5LswbpoIe552EUGjluKiadBig==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.41",
-				"@aws-sdk/credential-provider-http": "^3.972.43",
-				"@aws-sdk/credential-provider-ini": "^3.972.45",
-				"@aws-sdk/credential-provider-process": "^3.972.41",
-				"@aws-sdk/credential-provider-sso": "^3.972.45",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.45",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/credential-provider-imds": "^4.3.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/credential-provider-env": "^3.972.43",
+				"@aws-sdk/credential-provider-http": "^3.972.45",
+				"@aws-sdk/credential-provider-ini": "^3.972.48",
+				"@aws-sdk/credential-provider-process": "^3.972.43",
+				"@aws-sdk/credential-provider-sso": "^3.972.47",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.47",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/credential-provider-imds": "^4.3.7",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -898,15 +713,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
-			"integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.43.tgz",
+			"integrity": "sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -914,17 +729,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
-			"integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+			"version": "3.972.47",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.47.tgz",
+			"integrity": "sha512-0AzvLrzlvJs0DzbeWGvNj+bX3Uzd7VNS6vDqCOdZzBlCGKGd78uxctJSW9iK/Rt/nxiJqpTvrYQlVJ4guVM2Dw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/nested-clients": "^3.997.13",
-				"@aws-sdk/token-providers": "3.1056.0",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/nested-clients": "^3.997.15",
+				"@aws-sdk/token-providers": "3.1060.0",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -932,16 +747,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
-			"integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+			"version": "3.972.47",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.47.tgz",
+			"integrity": "sha512-eksfbUErOejUAGWBAcNqaP7IX21oUOEo73d9R56k9Ua4d57qS90NEYkWJsuSGzTXMFulCu17qXJI/qGmM7hvoA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/nested-clients": "^3.997.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/nested-clients": "^3.997.15",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -949,20 +764,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
-			"integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+			"version": "3.997.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.15.tgz",
+			"integrity": "sha512-Fpri1/PXKMKveORZ7E00VLTlWS5DkfZkW70PUE+bOnpWpAeHAQLoiDHhkzN3kNWbbSsGg64+IZYiq/EZgME3Mg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.30",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/fetch-http-handler": "^5.4.5",
-				"@smithy/node-http-handler": "^4.7.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.31",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/fetch-http-handler": "^5.4.6",
+				"@smithy/node-http-handler": "^4.7.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -970,14 +785,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
-			"integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+			"version": "3.996.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
+			"integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/signature-v4": "^5.4.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/signature-v4": "^5.4.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -985,16 +800,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1056.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
-			"integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+			"version": "3.1060.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1060.0.tgz",
+			"integrity": "sha512-6NZaMKkFhpaNiwLpHi1sZaYjidL/lCJE6ME6NxwA8gv9vQna+Kr0j4OFwVoz6tANRWM3WbGz6jiPsGX/Vkjwow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.15",
-				"@aws-sdk/nested-clients": "^3.997.13",
-				"@aws-sdk/types": "^3.973.9",
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@aws-sdk/core": "^3.974.17",
+				"@aws-sdk/nested-clients": "^3.997.15",
+				"@aws-sdk/types": "^3.973.10",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1002,12 +817,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-			"integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+			"version": "3.973.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+			"integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1027,12 +842,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.26",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-			"integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+			"version": "3.972.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+			"integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
@@ -3093,25 +2908,25 @@
 			}
 		},
 		"node_modules/@inquirer/ansi": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.6.tgz",
-			"integrity": "sha512-I/INw4sHGlVZ/afZOckpLiDP9SmbMl1g/GCqeHjLw1Afw/0PlRs2tRFgTGWmdI0hoNuWZn3y2iHNmG1vyECyQQ==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.0.tgz",
-			"integrity": "sha512-USpeB76eqK7yGricDlGAupxWlp4a59qpeZOoNWaxO/nJln7agpJveyNkQ1d5u8YXG6TOqxZtQpKPORQQDrdVsA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+			"integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^11.2.0",
-				"@inquirer/type": "^4.0.6"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -3123,21 +2938,21 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.0.tgz",
-			"integrity": "sha512-joR1YS2sI0us+9d0I8ViqFbrRLONO8CFTuyvBX4ZVBSch+VsZiugUABdrhBXXJR1VyEzvpz5SQCix3keETQ58g==",
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+			"integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^2.0.6",
-				"@inquirer/figures": "^2.0.6",
-				"@inquirer/type": "^4.0.6",
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7",
 				"cli-width": "^4.1.0",
 				"fast-wrap-ansi": "^0.2.0",
-				"mute-stream": "^4.0.0",
+				"mute-stream": "^3.0.0",
 				"signal-exit": "^4.1.0"
 			},
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -3149,25 +2964,25 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.6.tgz",
-			"integrity": "sha512-dsZgQtH2t5Q6ah3aPbZbeEZAxsD9qQu0DXf01AltuEfRTm+NoLN6+rLVbr+4edeEbNCp/wBNM6mALRWtsQpfkw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+			"integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.0.tgz",
-			"integrity": "sha512-sVZCz6P6e8tW5g2bSFel1oLpa6jK/u7BexFfrgTqR8syIdnHqy+iopnlSbYBZMsCK52chLjhGNBxt0eRqhsghw==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+			"integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^11.2.0",
-				"@inquirer/type": "^4.0.6"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -3179,18 +2994,18 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.0.tgz",
-			"integrity": "sha512-6IzkcmEbEXfgVbxZ2d1UyJFbCBoc6dTofulFmrYuomIp88HXiVqRbqbg4/mbfZhvnNo6xYmnYo2AEmDof6fQkg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+			"integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/ansi": "^2.0.6",
-				"@inquirer/core": "^11.2.0",
-				"@inquirer/figures": "^2.0.6",
-				"@inquirer/type": "^4.0.6"
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -3202,12 +3017,12 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.6.tgz",
-			"integrity": "sha512-J+9tdxOskuYuGjsvGaq00AamhDgjR7anhEW2dP4QdQpFCMPngCeC/bCYWQ5NsMWZRdsy53is7kAHb/+7cwDk2g==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -5225,13 +5040,13 @@
 			]
 		},
 		"node_modules/@scalar/client-side-rendering": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.12.tgz",
-			"integrity": "sha512-prwHK4ozTU268BHZ/5OstoKB23JSidDuvddAOp0bVz9c29ZxsyzzxPtPcVgF7X16LiZnS1OzY030FoDCM+iC9Q==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.13.tgz",
+			"integrity": "sha512-p8V4HgEWjaCpqsnhclg1pTfjE9JA0AWRr0ocBQHexoHo+pqnSs1d83Mv9rjH7R0FZJrlCSandZZeY3DMX2gYXQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/schemas": "0.3.2",
-				"@scalar/types": "0.12.2",
+				"@scalar/schemas": "0.3.3",
+				"@scalar/types": "0.12.3",
 				"@scalar/validation": "0.6.0"
 			},
 			"engines": {
@@ -5239,21 +5054,21 @@
 			}
 		},
 		"node_modules/@scalar/helpers": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
-			"integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.1.tgz",
+			"integrity": "sha512-yuiuBCadP5bjAnIv23QvifVN/NaMi9xBF6b8Wdk4QOzwzLPJmp699MAdf33J0A5i2qKcvnu32iz/VkEJmQRe5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@scalar/hono-api-reference": {
-			"version": "0.10.19",
-			"resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.10.19.tgz",
-			"integrity": "sha512-6EfwN/lfPvePzAxe9UE8fr/ZuAAqS6ttUwQu9JTgk2Xl/clicaVVSOc0gyGt+8GLXdysoNinjZ74we8xqNWyCA==",
+			"version": "0.10.20",
+			"resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.10.20.tgz",
+			"integrity": "sha512-/Ae0M9rOpsJJb5b121G8LX4vvBo1t2qFX1ffRKkTgCS9VWfpsfq11r0yBcYy1fmAn1x8YLO21Ls1/9h8LzHuDw==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/client-side-rendering": "0.1.12"
+				"@scalar/client-side-rendering": "0.1.13"
 			},
 			"engines": {
 				"node": ">=22"
@@ -5263,12 +5078,12 @@
 			}
 		},
 		"node_modules/@scalar/schemas": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.3.2.tgz",
-			"integrity": "sha512-iadXBgJ02XUU5C5s6/xh/PmGLzUPd7X8upXIvPWBXDcQ4FHACNgkG8PPZ/beYM8UPDDkTUPM3ygEs0G6jKwGjQ==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.3.3.tgz",
+			"integrity": "sha512-qDcgFu6ta5Z90L9D2P6DFKzYesU+FW5+m55SGmdI4iRMRCwj5umHpec2Y2W/SJcCF6bbUZawMxuOH2Ja6rUNpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/helpers": "0.8.0",
+				"@scalar/helpers": "0.8.1",
 				"@scalar/validation": "0.6.0"
 			},
 			"engines": {
@@ -5276,12 +5091,12 @@
 			}
 		},
 		"node_modules/@scalar/types": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.12.2.tgz",
-			"integrity": "sha512-EzLkubCb7xioiTm9eYnmn/032akaq4kkrrdclgV2uezwtniR8ErQICjhMl2AjBWL6nstHiFZ9RnPZm2Z2/KM0Q==",
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.12.3.tgz",
+			"integrity": "sha512-7zaXafbgTFmsJ/9AwYeExUWzXoZNyKOL0SEVAUWRaOndcjxpFCtwzuPrc1elMEWdHopWbY1Qe5pWKbE2aqG2HA==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/helpers": "0.8.0",
+				"@scalar/helpers": "0.8.1",
 				"nanoid": "^5.1.6",
 				"type-fest": "^5.3.1",
 				"zod": "^4.3.5"
@@ -5361,13 +5176,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@shikijs/core": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
-			"integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+			"integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/primitive": "4.1.0",
-				"@shikijs/types": "4.1.0",
+				"@shikijs/primitive": "4.2.0",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4",
 				"hast-util-to-html": "^9.0.5"
@@ -5377,9 +5192,9 @@
 			}
 		},
 		"node_modules/@shikijs/core/node_modules/@shikijs/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -5390,12 +5205,12 @@
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
-			"integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+			"integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.1.0",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"oniguruma-to-es": "^4.3.6"
 			},
@@ -5404,9 +5219,9 @@
 			}
 		},
 		"node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -5438,12 +5253,12 @@
 			}
 		},
 		"node_modules/@shikijs/primitive": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
-			"integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+			"integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.1.0",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			},
@@ -5452,9 +5267,9 @@
 			}
 		},
 		"node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -5472,6 +5287,32 @@
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/types": "3.23.0"
+			}
+		},
+		"node_modules/@shikijs/transformers": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.2.0.tgz",
+			"integrity": "sha512-pKrYVNUr1oPjJvs76gkPPirDySx3GKG9O88P2Y3AQ+7AjSFws9Y+Ry/Q/6Yg6QpyigzjdQ6H5JAMNAvLXZ63dw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "4.2.0",
+				"@shikijs/types": "4.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@shikijs/types": {
@@ -5549,13 +5390,13 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-			"integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+			"version": "3.24.6",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+			"integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.2",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5563,13 +5404,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.5.tgz",
-			"integrity": "sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==",
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+			"integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5577,13 +5418,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
-			"integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+			"integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5603,13 +5444,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
-			"integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+			"integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5617,13 +5458,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
-			"integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+			"integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.24.5",
-				"@smithy/types": "^4.14.2",
+				"@smithy/core": "^3.24.6",
+				"@smithy/types": "^4.14.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5631,9 +5472,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"version": "4.14.3",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+			"integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -6228,68 +6069,6 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/activity/node_modules/@temporalio/common": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
-			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.17.2",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/@temporalio/proto": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
-			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.5.5"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/@temporalio/client": {
 			"version": "1.17.2",
 			"resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.17.2.tgz",
@@ -6307,7 +6086,7 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/client/node_modules/@temporalio/common": {
+		"node_modules/@temporalio/common": {
 			"version": "1.17.2",
 			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
 			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
@@ -6323,50 +6102,13 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/client/node_modules/@temporalio/proto": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
-			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.5.5"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/client/node_modules/ms": {
+		"node_modules/@temporalio/common/node_modules/ms": {
 			"version": "3.0.0-canary.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
 			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.13"
-			}
-		},
-		"node_modules/@temporalio/client/node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/@temporalio/core-bridge": {
@@ -6382,66 +6124,86 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/@temporalio/common": {
+		"node_modules/@temporalio/interceptors-opentelemetry": {
 			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
-			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
+			"resolved": "https://registry.npmjs.org/@temporalio/interceptors-opentelemetry/-/interceptors-opentelemetry-1.17.2.tgz",
+			"integrity": "sha512-D2ZU/59dAC+b1rjLgVFhmwdJaIQUL+Sb/QhrZxv7eNzHgfc1/bon0kzGWIhdSr8FgEVZEMIhSx62JyLN9WXwIw==",
 			"license": "MIT",
 			"dependencies": {
-				"@temporalio/proto": "1.17.2",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.25.1",
+				"@opentelemetry/resources": "^1.25.1",
+				"@opentelemetry/sdk-trace-base": "^1.25.1",
+				"@temporalio/plugin": "1.17.2"
 			},
 			"engines": {
 				"node": ">= 20.0.0"
+			},
+			"peerDependencies": {
+				"@temporalio/common": "1.17.2",
+				"@temporalio/workflow": "1.17.2"
+			},
+			"peerDependenciesMeta": {
+				"@temporalio/workflow": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/@temporalio/proto": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
-			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
-			"license": "MIT",
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.5.5"
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
-				"node": ">= 20.0.0"
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
-		"node_modules/@temporalio/core-bridge/node_modules/protobufjs": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/resources": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.4",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.0",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.0",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/resources": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@temporalio/nexus": {
@@ -6460,23 +6222,16 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/@temporalio/common": {
+		"node_modules/@temporalio/plugin": {
 			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
-			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
+			"resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.17.2.tgz",
+			"integrity": "sha512-vBWHNf+0R3+yfb/LVQKWrzlXuwGWQjb88+5mfFCfGQaxyMeHzkQQBMNJ5NIoCLJsnwhs+1U93hldQ8j+fDL4yg==",
 			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.17.2",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
 			"engines": {
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/@temporalio/proto": {
+		"node_modules/@temporalio/proto": {
 			"version": "1.17.2",
 			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
 			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
@@ -6489,16 +6244,7 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
-		"node_modules/@temporalio/nexus/node_modules/protobufjs": {
+		"node_modules/@temporalio/proto/node_modules/protobufjs": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
 			"integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
@@ -6555,58 +6301,6 @@
 				"node": ">= 20.0.0"
 			}
 		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/common": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.17.2.tgz",
-			"integrity": "sha512-E+eR17bc/vR7HrmJBLCUq/asQplOUbl2Tm+JQgeK/fbSEAH2KJNL3sAVxx4/32KnOciKOYuV450brEicSNtnwQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.17.2",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/proto": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.17.2.tgz",
-			"integrity": "sha512-ecsk9F8863/FBwipQjJtuO/kEzWpIU9poAx+/twnJOesZW5dOabw7hYuqfUQul2H5MWm25qUvgU+SgLEgwr3zw==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.5.5"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/workflow": {
-			"version": "1.17.2",
-			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.17.2.tgz",
-			"integrity": "sha512-eRnZfjfaL9gSmVCOk6zRCE9QKQSyLgnlhnOKMjeIqGJeZC8XAYA16A5HKv2Uf3UiE2EcqRhak+uRPZP9qnTrmQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/common": "1.17.2",
-				"@temporalio/proto": "1.17.2",
-				"nexus-rpc": "^0.0.2"
-			},
-			"engines": {
-				"node": ">= 20.0.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
 		"node_modules/@temporalio/worker/node_modules/protobufjs": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
@@ -6644,6 +6338,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/@temporalio/workflow": {
+			"version": "1.17.2",
+			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.17.2.tgz",
+			"integrity": "sha512-eRnZfjfaL9gSmVCOk6zRCE9QKQSyLgnlhnOKMjeIqGJeZC8XAYA16A5HKv2Uf3UiE2EcqRhak+uRPZP9qnTrmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@temporalio/common": "1.17.2",
+				"@temporalio/proto": "1.17.2",
+				"nexus-rpc": "^0.0.2"
+			},
+			"engines": {
+				"node": ">= 20.0.0"
 			}
 		},
 		"node_modules/@testcontainers/nats": {
@@ -7216,9 +6924,9 @@
 			}
 		},
 		"node_modules/@types/react": {
-			"version": "19.2.15",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-			"integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+			"version": "19.2.16",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+			"integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -7425,14 +7133,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-			"integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+			"integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.7",
+				"@vitest/utils": "4.1.8",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -7446,8 +7154,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.7",
-				"vitest": "4.1.7"
+				"@vitest/browser": "4.1.8",
+				"vitest": "4.1.8"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -7456,16 +7164,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-			"integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -7474,13 +7182,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-			"integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.7",
+				"@vitest/spy": "4.1.8",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -7501,9 +7209,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-			"integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7514,13 +7222,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-			"integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.7",
+				"@vitest/utils": "4.1.8",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -7528,14 +7236,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-			"integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -7544,9 +7252,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-			"integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -7554,13 +7262,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-			"integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.7",
+				"@vitest/pretty-format": "4.1.8",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -7733,24 +7441,34 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@xyflow/react": {
-			"version": "12.10.2",
-			"resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
-			"integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+			"version": "12.11.0",
+			"resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+			"integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
 			"license": "MIT",
 			"dependencies": {
-				"@xyflow/system": "0.0.76",
+				"@xyflow/system": "0.0.77",
 				"classcat": "^5.0.3",
 				"zustand": "^4.4.0"
 			},
 			"peerDependencies": {
+				"@types/react": ">=17",
+				"@types/react-dom": ">=17",
 				"react": ">=17",
 				"react-dom": ">=17"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@xyflow/system": {
-			"version": "0.0.76",
-			"resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
-			"integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+			"version": "0.0.77",
+			"resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+			"integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/d3-drag": "^3.0.7",
@@ -8145,9 +7863,9 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
-			"integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-6.4.3.tgz",
+			"integrity": "sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==",
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/compiler": "^4.0.0",
@@ -8164,7 +7882,7 @@
 				"clsx": "^2.1.1",
 				"common-ancestor-path": "^2.0.0",
 				"cookie": "^1.1.1",
-				"devalue": "^5.6.3",
+				"devalue": "^5.8.1",
 				"diff": "^8.0.3",
 				"dset": "^3.1.4",
 				"es-module-lexer": "^2.0.0",
@@ -15338,12 +15056,12 @@
 			}
 		},
 		"node_modules/mute-stream": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-4.0.0.tgz",
-			"integrity": "sha512-gSrprq0fJ3EiOErzjdIZrjysVVmJ4uu1QWfCDss5LypA5OXvrMje5Ym5z6V6RLyJ2eF87lasX7t6a0AnFvZblg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
 			"license": "ISC",
 			"engines": {
-				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/nan": {
@@ -15711,12 +15429,12 @@
 			}
 		},
 		"node_modules/openapi3-ts": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
-			"integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.6.0.tgz",
+			"integrity": "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg==",
 			"license": "MIT",
 			"dependencies": {
-				"yaml": "^2.8.0"
+				"yaml": "^2.9.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -16044,9 +15762,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -16063,7 +15781,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -16326,24 +16044,24 @@
 			"license": "MIT"
 		},
 		"node_modules/react": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-			"integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "19.2.6",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-			"integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+			"integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
 			"license": "MIT",
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
 			"peerDependencies": {
-				"react": "^19.2.6"
+				"react": "^19.2.7"
 			}
 		},
 		"node_modules/react-is-18": {
@@ -17208,17 +16926,17 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
-			"integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+			"integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "4.1.0",
-				"@shikijs/engine-javascript": "4.1.0",
-				"@shikijs/engine-oniguruma": "4.1.0",
-				"@shikijs/langs": "4.1.0",
-				"@shikijs/themes": "4.1.0",
-				"@shikijs/types": "4.1.0",
+				"@shikijs/core": "4.2.0",
+				"@shikijs/engine-javascript": "4.2.0",
+				"@shikijs/engine-oniguruma": "4.2.0",
+				"@shikijs/langs": "4.2.0",
+				"@shikijs/themes": "4.2.0",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2",
 				"@types/hast": "^3.0.4"
 			},
@@ -17227,12 +16945,12 @@
 			}
 		},
 		"node_modules/shiki/node_modules/@shikijs/engine-oniguruma": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
-			"integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+			"integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.1.0",
+				"@shikijs/types": "4.2.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			},
 			"engines": {
@@ -17240,33 +16958,33 @@
 			}
 		},
 		"node_modules/shiki/node_modules/@shikijs/langs": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
-			"integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+			"integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.1.0"
+				"@shikijs/types": "4.2.0"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/shiki/node_modules/@shikijs/themes": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
-			"integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+			"integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "4.1.0"
+				"@shikijs/types": "4.2.0"
 			},
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/shiki/node_modules/@shikijs/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+			"integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
 			"license": "MIT",
 			"dependencies": {
 				"@shikijs/vscode-textmate": "^10.0.2",
@@ -18072,9 +17790,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
@@ -18281,9 +17999,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.22.3",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-			"integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18837,9 +18555,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-			"integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+			"integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.27.0",
@@ -19416,19 +19134,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-			"integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.7",
-				"@vitest/mocker": "4.1.7",
-				"@vitest/pretty-format": "4.1.7",
-				"@vitest/runner": "4.1.7",
-				"@vitest/snapshot": "4.1.7",
-				"@vitest/spy": "4.1.7",
-				"@vitest/utils": "4.1.7",
+				"@vitest/expect": "4.1.8",
+				"@vitest/mocker": "4.1.8",
+				"@vitest/pretty-format": "4.1.8",
+				"@vitest/runner": "4.1.8",
+				"@vitest/snapshot": "4.1.8",
+				"@vitest/spy": "4.1.8",
+				"@vitest/utils": "4.1.8",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -19456,12 +19174,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.7",
-				"@vitest/browser-preview": "4.1.7",
-				"@vitest/browser-webdriverio": "4.1.7",
-				"@vitest/coverage-istanbul": "4.1.7",
-				"@vitest/coverage-v8": "4.1.7",
-				"@vitest/ui": "4.1.7",
+				"@vitest/browser-playwright": "4.1.8",
+				"@vitest/browser-preview": "4.1.8",
+				"@vitest/browser-webdriverio": "4.1.8",
+				"@vitest/coverage-istanbul": "4.1.8",
+				"@vitest/coverage-v8": "4.1.8",
+				"@vitest/ui": "4.1.8",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -20027,7 +19745,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20038,7 +19756,7 @@
 			"version": "3.0.1",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-ssm": "^3.1056.0",
+				"@aws-sdk/client-ssm": "^3.1060.0",
 				"@purista/core": "*"
 			},
 			"devDependencies": {
@@ -20046,7 +19764,7 @@
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.1",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20057,7 +19775,7 @@
 			"version": "3.0.1",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-secrets-manager": "^3.1056.0",
+				"@aws-sdk/client-secrets-manager": "^3.1060.0",
 				"@purista/core": "*"
 			},
 			"devDependencies": {
@@ -20065,7 +19783,7 @@
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.1",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20086,7 +19804,7 @@
 				"dotenv": "^17.4.2",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.1",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20107,7 +19825,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20118,9 +19836,9 @@
 			"version": "3.0.1",
 			"license": "ISC",
 			"dependencies": {
-				"@inquirer/confirm": "^6.1.0",
-				"@inquirer/input": "^5.1.0",
-				"@inquirer/select": "^5.2.0",
+				"@inquirer/confirm": "^6.1.1",
+				"@inquirer/input": "^5.1.2",
+				"@inquirer/select": "^5.2.1",
 				"code-block-writer": "^13.0.3",
 				"commander": "^15.0.0",
 				"sinon": "^22.0.0",
@@ -20135,8 +19853,8 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"rimraf": "^6.1.3",
-				"tsx": "^4.22.3",
-				"type-fest": "^5.6.0"
+				"tsx": "^4.22.4",
+				"type-fest": "^5.7.0"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20149,6 +19867,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.12.0"
+			}
+		},
+		"packages/cli/node_modules/type-fest": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"packages/core": {
@@ -20164,7 +19898,7 @@
 				"@sodaru/yup-to-json-schema": "^2.0.1",
 				"@standard-schema/spec": "^1.1.0",
 				"code-block-writer": "^13.0.3",
-				"openapi3-ts": "^4.5.0",
+				"openapi3-ts": "^4.6.0",
 				"pino": "^10.3.1",
 				"sinon": "^22.0.0",
 				"ts-deepmerge": "^8.0.0",
@@ -20174,7 +19908,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"rimraf": "^6.1.3",
-				"vitest": "^4.1.7",
+				"vitest": "^4.1.8",
 				"yup": "^1.7.1"
 			},
 			"engines": {
@@ -20197,7 +19931,7 @@
 				"@types/sinon": "^21.0.1",
 				"hono": "^4.12.23",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20215,7 +19949,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20236,7 +19970,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20256,7 +19990,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20277,7 +20011,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20300,7 +20034,7 @@
 				"@types/sinon": "^21.0.1",
 				"@types/ws": "^8.18.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20319,7 +20053,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20336,7 +20070,7 @@
 			"devDependencies": {
 				"@testcontainers/nats": "^12.0.1",
 				"@types/node": "^25.9.1",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20355,7 +20089,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20379,7 +20113,7 @@
 				"@types/sinon": "^21.0.1",
 				"@types/ws": "^8.18.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20397,7 +20131,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20415,7 +20149,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20433,7 +20167,7 @@
 				"@types/node": "^25.9.1",
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20452,7 +20186,7 @@
 				"@types/sinon": "^21.0.1",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.1",
-				"vitest": "^4.1.7"
+				"vitest": "^4.1.8"
 			},
 			"engines": {
 				"node": ">=24.15.0"
@@ -20463,60 +20197,34 @@
 			"version": "3.0.1",
 			"dependencies": {
 				"@astrojs/mdx": "^6.0.1",
-				"@astrojs/react": "^5.0.6",
+				"@astrojs/react": "^5.0.7",
 				"@fontsource/inter": "^5.2.8",
 				"@sebastianwessel/isostate": "^0.4.0",
-				"@shikijs/transformers": "^4.1.0",
+				"@shikijs/transformers": "^4.2.0",
 				"@tailwindcss/vite": "^4.3.0",
 				"@types/gsap": "^3.0.0",
-				"@types/react": "^19.2.15",
+				"@types/react": "^19.2.16",
 				"@types/react-dom": "^19.2.3",
 				"@types/three": "^0.184.1",
-				"@xyflow/react": "^12.10.2",
-				"astro": "^6.4.2",
+				"@xyflow/react": "^12.11.0",
+				"astro": "^6.4.3",
 				"astro-og-canvas": "^0.11.1",
 				"beautiful-mermaid": "^1.1.3",
 				"gsap": "^3.15.0",
 				"lenis": "^1.3.23",
 				"mermaid": "^11.15.0",
-				"react": "^19.2.6",
-				"react-dom": "^19.2.6",
-				"shiki": "^4.1.0",
+				"react": "^19.2.7",
+				"react-dom": "^19.2.7",
+				"shiki": "^4.2.0",
 				"tailwindcss": "^4.3.0",
 				"three": "^0.184.0"
 			},
 			"devDependencies": {
 				"@sebastianwessel/isostate-cli": "^0.4.0",
-				"vite": "^8.0.14"
+				"vite": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=22.0.0"
-			}
-		},
-		"web/node_modules/@shikijs/transformers": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.1.0.tgz",
-			"integrity": "sha512-YbuOcAA3kwqKDU9YSt00dtFLrY5lBXjKU3dWaMATyEyPSqBm9Jqblk/uVICxz7lcjwAHzYaEvIiMWX3mTpogkA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/core": "4.1.0",
-				"@shikijs/types": "4.1.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"web/node_modules/@shikijs/types": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-			"integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=20"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@biomejs/biome": "^2.4.16",
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
-		"@vitest/coverage-v8": "^4.1.7",
+		"@vitest/coverage-v8": "^4.1.8",
 		"check-dependency-version-consistency": "^6.0.0",
 		"git-cliff": "^2.13.1",
 		"npm-check-updates": "^22.2.1",
@@ -54,15 +54,15 @@
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.1",
 		"ts-node": "^10.9.2",
-		"tsx": "^4.22.3",
+		"tsx": "^4.22.4",
 		"typedoc": "^0.28.19",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"packageManager": "npm@11.16.0",
 	"overrides": {
 		"protobufjs": "7.5.8",
-		"vite": "7.3.3"
+		"vite": "7.3.5"
 	},
 	"engines": {
 		"node": ">=24.15.0"

--- a/packages/amqpbridge/package.json
+++ b/packages/amqpbridge/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/aws-config-store/package.json
+++ b/packages/aws-config-store/package.json
@@ -39,10 +39,10 @@
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.1",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
-		"@aws-sdk/client-ssm": "^3.1056.0",
+		"@aws-sdk/client-ssm": "^3.1060.0",
 		"@purista/core": "*"
 	},
 	"peerDependenciesMeta": {},

--- a/packages/aws-secret-store/package.json
+++ b/packages/aws-secret-store/package.json
@@ -39,10 +39,10 @@
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.1",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
-		"@aws-sdk/client-secrets-manager": "^3.1056.0",
+		"@aws-sdk/client-secrets-manager": "^3.1060.0",
 		"@purista/core": "*"
 	},
 	"peerDependenciesMeta": {},

--- a/packages/azure-secret-store/package.json
+++ b/packages/azure-secret-store/package.json
@@ -40,7 +40,7 @@
 		"dotenv": "^17.4.2",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.1",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@azure/identity": "^4.13.1",

--- a/packages/base-http-bridge/package.json
+++ b/packages/base-http-bridge/package.json
@@ -25,7 +25,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,13 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"rimraf": "^6.1.3",
-		"tsx": "^4.22.3",
-		"type-fest": "^5.6.0"
+		"tsx": "^4.22.4",
+		"type-fest": "^5.7.0"
 	},
 	"dependencies": {
-		"@inquirer/confirm": "^6.1.0",
-		"@inquirer/input": "^5.1.0",
-		"@inquirer/select": "^5.2.0",
+		"@inquirer/confirm": "^6.1.1",
+		"@inquirer/input": "^5.1.2",
+		"@inquirer/select": "^5.2.1",
 		"code-block-writer": "^13.0.3",
 		"commander": "^15.0.0",
 		"sinon": "^22.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"rimraf": "^6.1.3",
-		"vitest": "^4.1.7",
+		"vitest": "^4.1.8",
 		"yup": "^1.7.1"
 	},
 	"dependencies": {
@@ -42,7 +42,7 @@
 		"@sodaru/yup-to-json-schema": "^2.0.1",
 		"@standard-schema/spec": "^1.1.0",
 		"code-block-writer": "^13.0.3",
-		"openapi3-ts": "^4.5.0",
+		"openapi3-ts": "^4.6.0",
 		"pino": "^10.3.1",
 		"sinon": "^22.0.0",
 		"ts-deepmerge": "^8.0.0",

--- a/packages/core/src/QueueDefinitionBuilder/QueueDefinitionBuilder.impl.ts
+++ b/packages/core/src/QueueDefinitionBuilder/QueueDefinitionBuilder.impl.ts
@@ -5,7 +5,7 @@ import type { QueueLongRunningExecutionProfile } from '../core/types/queue/Queue
 import type { QueueLifecycleConfig } from '../core/types/queue/QueueLifecycleConfig.js'
 import type { QueueResultPolicy } from '../core/types/queue/QueueResultPolicy.js'
 import type { QueueTransformHook } from '../core/types/queue/QueueTransformHook.js'
-import type { QueueWorkerDefinition } from '../core/types/queue/QueueWorkerDefinition.js'
+import type { AnyQueueWorkerDefinition } from '../core/types/queue/QueueWorkerDefinitionList.js'
 import type { ScheduleDefinition, ScheduleOptions } from '../core/types/schedule/index.js'
 import type { Schema } from '../schema/index.js'
 
@@ -36,7 +36,7 @@ export class QueueDefinitionBuilder {
 	private beforeExecuteTransform?: QueueTransformHook
 	private tags: string[] = []
 	private deprecated = false
-	private workers: QueueWorkerDefinition[] = []
+	private workers: AnyQueueWorkerDefinition[] = []
 	private deadLetter?: { queueName?: string }
 	private queueBridgeConfig: DefinitionQueueBridgeConfig = {
 		prefetch: 1,
@@ -211,7 +211,7 @@ export class QueueDefinitionBuilder {
 	}
 
 	/** Attach one or more worker definitions that can process jobs from this queue. */
-	addWorkerDefinition(...workers: QueueWorkerDefinition[]) {
+	addWorkerDefinition(...workers: AnyQueueWorkerDefinition[]) {
 		this.workers.push(...workers)
 		return this
 	}

--- a/packages/core/src/QueueWorkerBuilder/QueueWorkerBuilder.impl.ts
+++ b/packages/core/src/QueueWorkerBuilder/QueueWorkerBuilder.impl.ts
@@ -1,4 +1,13 @@
-import { getNamedHook, mergeNamedHooks } from '../core/helper/builderRegistry.impl.js'
+import type { AllowedAgentDefinition } from '../AgentQueueBuilder/types.js'
+import {
+	getNamedHook,
+	mergeNamedHooks,
+	registerEmitSchema,
+	registerInvokeCapability,
+	registerStreamInvokeCapability,
+} from '../core/helper/builderRegistry.impl.js'
+import type { EmptyObject } from '../core/types/EmptyObject.js'
+import type { QueueInvokeList } from '../core/types/queue/QueueInvokeList.js'
 import type { QueueWorkerAfterGuardHook } from '../core/types/queue/QueueWorkerAfterGuardHook.js'
 import type { QueueWorkerBeforeGuardHook } from '../core/types/queue/QueueWorkerBeforeGuardHook.js'
 import type {
@@ -6,6 +15,8 @@ import type {
 	QueueWorkerHandler,
 	QueueWorkerMode,
 } from '../core/types/queue/QueueWorkerDefinition.js'
+import type { Infer, InferIn, Schema } from '../schema/index.js'
+import type { QueueWorkerBuilderTypes } from './QueueWorkerBuilderTypes.js'
 
 /**
  * Builds a queue worker definition for one queue.
@@ -22,13 +33,28 @@ import type {
  *   .setHandler(async (context, job) => ({ status: 'success', output: job.payload }))
  * ```
  */
-export class QueueWorkerBuilder {
+export class QueueWorkerBuilder<S extends QueueWorkerBuilderTypes = QueueWorkerBuilderTypes> {
 	private mode: QueueWorkerMode = 'continuous'
 	private intervalMs?: number
 	private maxParallelHandlers = 1
-	private handler?: QueueWorkerHandler
+	private handler?: QueueWorkerHandler<
+		InferIn<S['PayloadSchema']>,
+		InferIn<S['ParamsSchema']>,
+		S['Resources'],
+		S['Invokes'],
+		S['StreamInvokes'],
+		S['EmitList'],
+		S['QueueInvokes'],
+		EmptyObject,
+		S['AgentInvokes']
+	>
 	private beforeGuards: Record<string, QueueWorkerBeforeGuardHook> = {}
 	private afterGuards: Record<string, QueueWorkerAfterGuardHook> = {}
+	private invokes: S['Invokes'] = {}
+	private streamInvokes: S['StreamInvokes'] = {}
+	private emitList: S['EmitList'] = {}
+	private queueInvokes: QueueInvokeList = {}
+	private agentInvokes: AllowedAgentDefinition[] = []
 
 	constructor(
 		private readonly queueName: string,
@@ -54,9 +80,239 @@ export class QueueWorkerBuilder {
 	}
 
 	/** Set the job handler implementation for this worker. */
-	setHandler(handler: QueueWorkerHandler) {
+	setHandler(
+		handler: QueueWorkerHandler<
+			InferIn<S['PayloadSchema']>,
+			InferIn<S['ParamsSchema']>,
+			S['Resources'],
+			S['Invokes'],
+			S['StreamInvokes'],
+			S['EmitList'],
+			S['QueueInvokes'],
+			EmptyObject,
+			S['AgentInvokes']
+		>,
+	) {
 		this.handler = handler
 		return this
+	}
+
+	/**
+	 * Declare a command this worker handler may invoke through `context.service`.
+	 *
+	 * @example
+	 * ```ts
+	 * worker.canInvoke('billing', '1', 'getInvoice', invoiceSchema, lookupSchema)
+	 * ```
+	 */
+	canInvoke<
+		Output extends Schema,
+		Payload extends Schema,
+		Parameter extends Schema,
+		SName extends string = string,
+		Version extends string = string,
+		Fname extends string = string,
+	>(
+		serviceName: SName,
+		serviceVersion: Version,
+		serviceTarget: Fname,
+		outputSchema?: Output,
+		payloadSchema?: Payload,
+		parameterSchema?: Parameter,
+	) {
+		this.invokes = registerInvokeCapability(
+			this.invokes as Record<
+				string,
+				Record<string, Record<string, { outputSchema?: Schema; payloadSchema?: Schema; parameterSchema?: Schema }>>
+			>,
+			serviceName,
+			serviceVersion,
+			serviceTarget,
+			{ outputSchema, payloadSchema, parameterSchema },
+		) as S['Invokes']
+
+		return this as unknown as QueueWorkerBuilder<
+			QueueWorkerBuilderTypes<
+				S['PayloadSchema'],
+				S['ParamsSchema'],
+				S['Resources'],
+				S['Invokes'] &
+					Record<
+						SName,
+						Record<
+							Version,
+							Record<Fname, (payload: InferIn<Payload>, parameter: InferIn<Parameter>) => Promise<Infer<Output>>>
+						>
+					>,
+				S['StreamInvokes'],
+				S['EmitList'],
+				S['QueueInvokes'],
+				S['AgentInvokes']
+			>
+		>
+	}
+
+	/**
+	 * Declare a stream this worker handler may consume through `context.stream`.
+	 */
+	canConsumeStream<
+		Chunk extends Schema,
+		Final extends Schema,
+		Payload extends Schema,
+		Parameter extends Schema,
+		SName extends string = string,
+		Version extends string = string,
+		Fname extends string = string,
+	>(
+		serviceName: SName,
+		serviceVersion: Version,
+		serviceTarget: Fname,
+		chunkSchema?: Chunk,
+		payloadSchema?: Payload,
+		parameterSchema?: Parameter,
+		finalSchema?: Final,
+		validateChunk = true,
+		validateFinal = true,
+	) {
+		this.streamInvokes = registerStreamInvokeCapability(
+			this.streamInvokes as Record<
+				string,
+				Record<
+					string,
+					Record<
+						string,
+						{
+							chunkSchema?: Schema
+							finalSchema?: Schema
+							payloadSchema?: Schema
+							parameterSchema?: Schema
+							validateChunk?: boolean
+							validateFinal?: boolean
+						}
+					>
+				>
+			>,
+			serviceName,
+			serviceVersion,
+			serviceTarget,
+			{ chunkSchema, finalSchema, payloadSchema, parameterSchema, validateChunk, validateFinal },
+		) as S['StreamInvokes']
+
+		return this as unknown as QueueWorkerBuilder<
+			QueueWorkerBuilderTypes<
+				S['PayloadSchema'],
+				S['ParamsSchema'],
+				S['Resources'],
+				S['Invokes'],
+				S['StreamInvokes'] &
+					Record<
+						SName,
+						Record<
+							Version,
+							Record<
+								Fname,
+								(
+									payload: InferIn<Payload>,
+									parameter: InferIn<Parameter>,
+								) => Promise<{
+									[Symbol.asyncIterator](): AsyncIterableIterator<Infer<Chunk>>
+									final: Promise<Infer<Final>>
+								}>
+							>
+						>
+					>,
+				S['EmitList'],
+				S['QueueInvokes'],
+				S['AgentInvokes']
+			>
+		>
+	}
+
+	/**
+	 * Declare a queue this worker handler may enqueue through `context.queue`.
+	 */
+	canEnqueue<Payload extends Schema, Parameter extends Schema, QueueName extends string = string>(
+		queueName: QueueName,
+		payloadSchema?: Payload,
+		parameterSchema?: Parameter,
+	) {
+		if (queueName.trim() === '') {
+			throw new Error('canEnqueue requires non-empty queue name')
+		}
+
+		this.queueInvokes = {
+			...this.queueInvokes,
+			[queueName]: { payloadSchema, parameterSchema },
+		}
+
+		return this as unknown as QueueWorkerBuilder<
+			QueueWorkerBuilderTypes<
+				S['PayloadSchema'],
+				S['ParamsSchema'],
+				S['Resources'],
+				S['Invokes'],
+				S['StreamInvokes'],
+				S['EmitList'],
+				S['QueueInvokes'] & Record<QueueName, { payloadSchema: Payload; parameterSchema: Parameter }>,
+				S['AgentInvokes']
+			>
+		>
+	}
+
+	/**
+	 * Declare a custom event this worker handler may emit through `context.emit`.
+	 */
+	canEmit<EventName extends string, T extends Schema>(eventName: EventName, schema: T) {
+		this.emitList = registerEmitSchema(this.emitList, eventName, schema) as S['EmitList']
+
+		return this as unknown as QueueWorkerBuilder<
+			QueueWorkerBuilderTypes<
+				S['PayloadSchema'],
+				S['ParamsSchema'],
+				S['Resources'],
+				S['Invokes'],
+				S['StreamInvokes'],
+				S['EmitList'] & Record<EventName, InferIn<T>>,
+				S['QueueInvokes'],
+				S['AgentInvokes']
+			>
+		>
+	}
+
+	/**
+	 * Declare a same-service agent this worker handler may invoke through `context.agent`.
+	 */
+	canInvokeAgent<
+		Output extends Schema,
+		Payload extends Schema,
+		Parameter extends Schema,
+		AgentName extends string,
+		Version extends string,
+	>(
+		agentName: AgentName,
+		serviceVersion: Version,
+		schemas?: { outputSchema?: Output; payloadSchema?: Payload; parameterSchema?: Parameter },
+	) {
+		this.agentInvokes.push({
+			agentName,
+			serviceVersion,
+			outputSchema: schemas?.outputSchema,
+			payloadSchema: schemas?.payloadSchema,
+			parameterSchema: schemas?.parameterSchema,
+		})
+
+		return this as unknown as QueueWorkerBuilder<
+			QueueWorkerBuilderTypes<
+				S['PayloadSchema'],
+				S['ParamsSchema'],
+				S['Resources'],
+				S['Invokes'],
+				S['StreamInvokes'],
+				S['EmitList'],
+				S['QueueInvokes'],
+				S['AgentInvokes'] & Record<`${AgentName}.${Version}`, AllowedAgentDefinition<Output, Payload, Parameter>>
+			>
+		>
 	}
 
 	/** Register named guard hooks that run before the worker handler. */
@@ -86,7 +342,19 @@ export class QueueWorkerBuilder {
 	}
 
 	/** Resolve this builder into the queue worker definition consumed by a service. */
-	async getDefinition(): Promise<QueueWorkerDefinition> {
+	async getDefinition(): Promise<
+		QueueWorkerDefinition<
+			S['PayloadSchema'],
+			S['ParamsSchema'],
+			S['Resources'],
+			S['Invokes'],
+			S['StreamInvokes'],
+			S['EmitList'],
+			S['QueueInvokes'],
+			EmptyObject,
+			S['AgentInvokes']
+		>
+	> {
 		if (!this.handler) {
 			throw new Error('QueueWorkerBuilder: missing handler implementation')
 		}
@@ -100,6 +368,11 @@ export class QueueWorkerBuilder {
 			handler: this.handler,
 			beforeGuards: this.beforeGuards,
 			afterGuards: this.afterGuards,
+			invokes: this.invokes,
+			streamInvokes: this.streamInvokes,
+			emitList: this.emitList,
+			queueInvokes: this.queueInvokes,
+			agentInvokes: this.agentInvokes,
 		}
 	}
 }

--- a/packages/core/src/QueueWorkerBuilder/QueueWorkerBuilderTypes.ts
+++ b/packages/core/src/QueueWorkerBuilder/QueueWorkerBuilderTypes.ts
@@ -1,0 +1,35 @@
+import type { AllowedAgentDefinition } from '../AgentQueueBuilder/types.js'
+import type { EmptyObject } from '../core/types/EmptyObject.js'
+import type { InvokeList } from '../core/types/InvokeList.js'
+import type { QueueInvokeList } from '../core/types/queue/QueueInvokeList.js'
+import type { StreamInvokeList } from '../core/types/StreamInvokeList.js'
+import type { Schema } from '../schema/index.js'
+
+/** Type accumulator used by `QueueWorkerBuilder` for handler capabilities. */
+export type QueueWorkerBuilderTypes<
+	PayloadSchema extends Schema = Schema,
+	ParamsSchema extends Schema = Schema,
+	Resources extends Record<string, unknown> = EmptyObject,
+	Invokes extends InvokeList = InvokeList,
+	StreamInvokes extends StreamInvokeList = StreamInvokeList,
+	EmitList extends Record<string, Schema> = Record<string, Schema>,
+	QueueInvokes extends QueueInvokeList = QueueInvokeList,
+	AgentInvokes extends Record<string, AllowedAgentDefinition> = Record<never, never>,
+> = {
+	/** Schema that validates the leased queue payload. */
+	PayloadSchema: PayloadSchema
+	/** Schema that validates the leased queue parameters. */
+	ParamsSchema: ParamsSchema
+	/** Service resources available in queue worker handlers and hooks. */
+	Resources: Resources
+	/** Commands this queue worker may invoke through the typed service proxy. */
+	Invokes: Invokes
+	/** Streams this queue worker may consume through the typed stream proxy. */
+	StreamInvokes: StreamInvokes
+	/** Custom events this queue worker may emit. */
+	EmitList: EmitList
+	/** Queues this queue worker may enqueue. */
+	QueueInvokes: QueueInvokes
+	/** Same-service agents this queue worker may invoke. */
+	AgentInvokes: AgentInvokes
+}

--- a/packages/core/src/QueueWorkerBuilder/index.ts
+++ b/packages/core/src/QueueWorkerBuilder/index.ts
@@ -1,1 +1,2 @@
 export * from './QueueWorkerBuilder.impl.js'
+export type * from './QueueWorkerBuilderTypes.js'

--- a/packages/core/src/QueueWorkerBuilder/queueWorkerBuilder.test.ts
+++ b/packages/core/src/QueueWorkerBuilder/queueWorkerBuilder.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { QueueWorkerBuilder } from './QueueWorkerBuilder.impl.js'
 
 describe('QueueWorkerBuilder', () => {
@@ -27,5 +28,57 @@ describe('QueueWorkerBuilder', () => {
 
 		expect(definition.beforeGuards?.auth).toBe(beforeGuard)
 		expect(definition.afterGuards?.audit).toBe(afterGuard)
+	})
+
+	it('includes declared handler capabilities in the worker definition', async () => {
+		const payloadSchema = z.object({ id: z.string() })
+		const parameterSchema = z.object({ tenantId: z.string() })
+		const outputSchema = z.object({ status: z.enum(['ok', 'failed']) })
+		const chunkSchema = z.object({ chunk: z.string() })
+		const finalSchema = z.object({ done: z.boolean() })
+		const eventSchema = z.object({ jobId: z.string() })
+
+		const definition = await new QueueWorkerBuilder('supportQueue', 'execute')
+			.canInvoke('TicketService', '1', 'loadTicket', outputSchema, payloadSchema, parameterSchema)
+			.canConsumeStream('ReportService', '1', 'streamReport', chunkSchema, payloadSchema, parameterSchema, finalSchema)
+			.canEnqueue('auditQueue', payloadSchema, parameterSchema)
+			.canEmit('worker.done', eventSchema)
+			.canInvokeAgent('triageTicket', '1', {
+				outputSchema,
+				payloadSchema,
+				parameterSchema,
+			})
+			.setHandler(async function handler() {
+				return { status: 'success' as const }
+			})
+			.getDefinition()
+
+		expect(definition.invokes.TicketService['1'].loadTicket).toMatchObject({
+			outputSchema,
+			payloadSchema,
+			parameterSchema,
+		})
+		expect(definition.streamInvokes.ReportService['1'].streamReport).toMatchObject({
+			chunkSchema,
+			finalSchema,
+			payloadSchema,
+			parameterSchema,
+			validateChunk: true,
+			validateFinal: true,
+		})
+		expect(definition.queueInvokes.auditQueue).toMatchObject({
+			payloadSchema,
+			parameterSchema,
+		})
+		expect(definition.emitList['worker.done']).toBe(eventSchema)
+		expect(definition.agentInvokes).toStrictEqual([
+			{
+				agentName: 'triageTicket',
+				serviceVersion: '1',
+				outputSchema,
+				payloadSchema,
+				parameterSchema,
+			},
+		])
 	})
 })

--- a/packages/core/src/core/Service/Service.impl.ts
+++ b/packages/core/src/core/Service/Service.impl.ts
@@ -1,5 +1,6 @@
 import type { Span } from '@opentelemetry/api'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
+import type { AgentInvokeMap, AllowedAgentDefinition } from '../../AgentQueueBuilder/types.js'
 import { DefaultConfigStore } from '../../DefaultConfigStore/DefaultConfigStore.impl.js'
 import { DefaultQueueBridge } from '../../DefaultQueueBridge/DefaultQueueBridge.impl.js'
 import { DefaultSecretStore } from '../../DefaultSecretStore/DefaultSecretStore.impl.js'
@@ -2373,19 +2374,49 @@ export class Service<S extends ServiceClassTypes<any, any, any> = ServiceClassTy
 		const traceId = lease.message.traceId
 		const principalId = readHeader('purista.principalId')
 		const tenantId = readHeader('purista.tenantId')
+		const queueClient = this.getQueueNamespace(
+			this.resolveQueueInvokes(worker.queueInvokes),
+			traceId,
+			principalId,
+			tenantId,
+		)
+		const serviceProxy = createInvokeFunctionProxy(
+			this.getInvokeFunction(worker.name, traceId, principalId, tenantId, worker.invokes),
+		)
 
 		return {
 			message: lease.message,
 			job: jobControls,
 			signal: cancellation.controller.signal,
-			emit: this.getEmitFunction(worker.name, traceId, principalId, tenantId, {}),
-			...this.getContextFunctions(logger),
-			service: createInvokeFunctionProxy(this.getInvokeFunction(worker.name, traceId, principalId, tenantId, {})),
+			emit: this.getEmitFunction(worker.name, traceId, principalId, tenantId, worker.emitList),
+			...this.getContextFunctions(logger, queueClient),
+			service: serviceProxy,
 			stream: createOpenStreamFunctionProxy(
-				this.getConsumeStreamFunction(worker.name, traceId, principalId, tenantId, {}),
+				this.getConsumeStreamFunction(worker.name, traceId, principalId, tenantId, worker.streamInvokes),
 			),
+			agent: this.createQueueWorkerAgentInvokeMap(serviceProxy, worker.agentInvokes),
 			resources: this.resources,
 		} as QueueJobContext
+	}
+
+	private createQueueWorkerAgentInvokeMap<Agents extends Record<string, AllowedAgentDefinition>>(
+		serviceProxy: unknown,
+		agents: readonly AllowedAgentDefinition[],
+	): AgentInvokeMap<Agents> {
+		const result: Record<string, { run(payload: unknown, parameter?: unknown): Promise<unknown> }> = {}
+		for (const agent of agents) {
+			const key = `${agent.agentName}.${agent.serviceVersion}`
+			result[key] = {
+				run: async (payload, parameter) => {
+					const serviceMap = serviceProxy as Record<
+						string,
+						Record<string, Record<string, (payload: unknown, parameter?: unknown) => Promise<unknown>>>
+					>
+					return serviceMap[this.info.serviceName][agent.serviceVersion][agent.agentName](payload, parameter)
+				},
+			}
+		}
+		return result as AgentInvokeMap<Agents>
 	}
 
 	private async handleQueueResult(

--- a/packages/core/src/core/types/queue/QueueDefinition.ts
+++ b/packages/core/src/core/types/queue/QueueDefinition.ts
@@ -51,7 +51,7 @@ export type QueueDefinition<
 	/** Required queue bridge capabilities for strict startup validation. */
 	queueBridgeConfig: DefinitionQueueBridgeConfig
 	/** Worker definitions that process messages from this queue. */
-	workers: QueueWorkerDefinition<PayloadSchema, ParamsSchema, Resources, Invokes, StreamInvokes>[]
+	workers: QueueWorkerDefinition<PayloadSchema, ParamsSchema, Resources, Invokes, StreamInvokes, any, any, any, any>[]
 	/** Optional dead-letter queue naming override. */
 	deadLetter?: {
 		queueName?: string

--- a/packages/core/src/core/types/queue/QueueJobContext.ts
+++ b/packages/core/src/core/types/queue/QueueJobContext.ts
@@ -1,3 +1,4 @@
+import type { AgentInvokeMap, AllowedAgentDefinition } from '../../../AgentQueueBuilder/types.js'
 import type { Schema } from '../../../schema/index.js'
 import type { QueueRetryRequest } from '../../QueueBridge/types/QueueRetryRequest.js'
 import type { ContextBase } from '../ContextBase.js'
@@ -52,6 +53,7 @@ export type QueueJobContext<
 	EmitList extends Record<string, Schema> = Record<string, never>,
 	QueueInvokes extends QueueInvokeList = QueueInvokeList,
 	Metrics extends PuristaMetricDefinitions = EmptyObject,
+	AgentInvokes extends Record<string, AllowedAgentDefinition> = Record<never, never>,
 > = ContextBase<Metrics> &
 	PuristaMetricContextProperty<Metrics> & {
 		/** Immutable queue message for this lease. */
@@ -68,6 +70,8 @@ export type QueueJobContext<
 		stream: StreamInvokes
 		/** Typed queue enqueue and schedule clients. */
 		queue: QueueContext<QueueInvokes>
+		/** Typed same-service agent invocation clients. */
+		agent: AgentInvokeMap<AgentInvokes>
 		/** Runtime resources supplied to the service. */
 		resources: Resources
 	}

--- a/packages/core/src/core/types/queue/QueueWorkerDefinition.ts
+++ b/packages/core/src/core/types/queue/QueueWorkerDefinition.ts
@@ -1,3 +1,4 @@
+import type { AllowedAgentDefinition } from '../../../AgentQueueBuilder/types.js'
 import type { InferIn, Schema } from '../../../schema/index.js'
 import type { EmptyObject } from '../EmptyObject.js'
 import type { InvokeList } from '../InvokeList.js'
@@ -35,6 +36,7 @@ export type QueueWorkerHandler<
 	EmitList extends Record<string, Schema> = Record<string, never>,
 	QueueInvokes extends QueueInvokeList = QueueInvokeList,
 	Metrics extends PuristaMetricDefinitions = EmptyObject,
+	AgentInvokes extends Record<string, AllowedAgentDefinition> = Record<never, never>,
 > = (
 	context: QueueJobContext<
 		MessagePayloadType,
@@ -44,7 +46,8 @@ export type QueueWorkerHandler<
 		StreamInvokes,
 		EmitList,
 		QueueInvokes,
-		Metrics
+		Metrics,
+		AgentInvokes
 	>,
 	message: QueueMessage<MessagePayloadType, MessageParamsType>,
 ) => Promise<QueueHandlerResult | undefined>
@@ -63,6 +66,7 @@ export type QueueWorkerDefinition<
 	EmitList extends Record<string, Schema> = Record<string, never>,
 	QueueInvokes extends QueueInvokeList = QueueInvokeList,
 	Metrics extends PuristaMetricDefinitions = EmptyObject,
+	AgentInvokes extends Record<string, AllowedAgentDefinition> = Record<never, never>,
 > = {
 	/** Worker name used in diagnostics and metrics. */
 	name: string
@@ -83,8 +87,19 @@ export type QueueWorkerDefinition<
 		StreamInvokes,
 		EmitList,
 		QueueInvokes,
-		Metrics
+		Metrics,
+		AgentInvokes
 	>
+	/** Commands this worker may invoke through the typed service proxy. */
+	invokes: Invokes
+	/** Streams this worker may consume through the typed stream proxy. */
+	streamInvokes: StreamInvokes
+	/** Custom events this worker may emit. */
+	emitList: EmitList
+	/** Queues this worker may enqueue. */
+	queueInvokes: QueueInvokes
+	/** Same-service agents this worker may invoke through the typed agent proxy. */
+	agentInvokes: readonly AllowedAgentDefinition[]
 	/** Guards that run before the worker handler. */
 	beforeGuards?: Record<
 		string,

--- a/packages/core/src/core/types/queue/QueueWorkerDefinitionList.ts
+++ b/packages/core/src/core/types/queue/QueueWorkerDefinitionList.ts
@@ -1,4 +1,6 @@
 import type { QueueWorkerDefinition } from './QueueWorkerDefinition.js'
 
-export type QueueWorkerDefinitionList<_S> = Promise<QueueWorkerDefinition>[]
-export type QueueWorkerDefinitionListResolved<_S> = QueueWorkerDefinition[]
+export type AnyQueueWorkerDefinition = QueueWorkerDefinition<any, any, any, any, any, any, any, any, any>
+
+export type QueueWorkerDefinitionList<_S> = Promise<AnyQueueWorkerDefinition>[]
+export type QueueWorkerDefinitionListResolved<_S> = AnyQueueWorkerDefinition[]

--- a/packages/core/src/testing/createQueueWorkerContextMock.ts
+++ b/packages/core/src/testing/createQueueWorkerContextMock.ts
@@ -1,18 +1,31 @@
 import type { SinonSandbox, SinonStub } from 'sinon'
 import { stub } from 'sinon'
+import { createQueueEnqueueProxy } from '../core/helper/createQueueEnqueueProxy.impl.js'
+import { createQueueScheduleProxy } from '../core/helper/createQueueScheduleProxy.impl.js'
 import { getNewCorrelationId } from '../core/helper/getNewCorrelationId.impl.js'
 import { getNewTraceId } from '../core/helper/getNewTraceId.impl.js'
 import type { QueueRetryRequest } from '../core/QueueBridge/types/QueueRetryRequest.js'
+import type { EmptyObject } from '../core/types/EmptyObject.js'
+import type { FromEmitToOtherType } from '../core/types/FromEmitToOtherType.js'
+import type { QueueInvokeFunction } from '../core/types/queue/QueueInvokeFunction.js'
+import type { QueueInvokeList } from '../core/types/queue/QueueInvokeList.js'
 import type { QueueJobContext } from '../core/types/queue/QueueJobContext.js'
 import type { QueueMessage } from '../core/types/queue/QueueMessage.js'
+import type { QueueScheduleFunction } from '../core/types/queue/QueueScheduleFunction.js'
 import type { QueueWorkerBuilder } from '../QueueWorkerBuilder/QueueWorkerBuilder.impl.js'
+import type { QueueWorkerBuilderTypes } from '../QueueWorkerBuilder/QueueWorkerBuilderTypes.js'
+import type { Schema } from '../schema/index.js'
 import {
+	createAgentInvokeProxy,
 	createBaseContextStubs,
 	createInvokeProxy,
 	createMetricContextMock,
 	createMockSpan,
 	createResourceProxy,
 } from './sharedContextMocks.js'
+
+/** Infer the internal builder type configuration from a queue worker builder. */
+export type QueueWorkerContextMockBuilderTypes<T> = T extends QueueWorkerBuilder<infer C> ? C : QueueWorkerBuilderTypes
 
 /**
  * Input for {@link createQueueWorkerContextMock}.
@@ -47,12 +60,23 @@ export type QueueWorkerContextMockResult<
 	Payload = unknown,
 	Parameter = unknown,
 	Resources extends Record<string, unknown> = Record<string, unknown>,
+	TBuilder extends QueueWorkerBuilder<any> = QueueWorkerBuilder<any>,
 > = {
-	context: QueueJobContext<Payload, Parameter, Resources>
+	context: QueueJobContext<
+		Payload,
+		Parameter,
+		Resources,
+		QueueWorkerContextMockBuilderTypes<TBuilder>['Invokes'],
+		QueueWorkerContextMockBuilderTypes<TBuilder>['StreamInvokes'],
+		QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList'],
+		QueueWorkerContextMockBuilderTypes<TBuilder>['QueueInvokes'],
+		EmptyObject,
+		QueueWorkerContextMockBuilderTypes<TBuilder>['AgentInvokes']
+	>
 	message: QueueMessage<Payload, Parameter>
 	stubs: {
 		logger: Record<string, SinonStub>
-		emit: SinonStub
+		emit: FromEmitToOtherType<QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList'], SinonStub>
 		wrapInSpan: SinonStub
 		startActiveSpan: SinonStub
 		getSecret: SinonStub
@@ -72,8 +96,11 @@ export type QueueWorkerContextMockResult<
 			extendLease: SinonStub
 			cancelRequested: SinonStub
 		}
-		service: QueueJobContext<Payload, Parameter, Resources>['service']
-		stream: QueueJobContext<Payload, Parameter, Resources>['stream']
+		service: QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context']['service']
+		stream: QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context']['stream']
+		agent: QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context']['agent']
+		enqueue: SinonStub
+		scheduleAt: SinonStub
 	}
 }
 
@@ -107,13 +134,25 @@ export const createQueueWorkerContextMock = <
 	Payload = unknown,
 	Parameter = unknown,
 	Resources extends Record<string, unknown> = Record<string, unknown>,
+	TBuilder extends QueueWorkerBuilder<any> = QueueWorkerBuilder<any>,
 >(
-	_builder: QueueWorkerBuilder,
+	builder: TBuilder,
 	input: CreateQueueWorkerContextMockInput<Payload, Parameter, Resources>,
-): QueueWorkerContextMockResult<Payload, Parameter, Resources> => {
-	const base = createBaseContextStubs<Resources, Record<string, never>>({} as Record<string, never>, input.sandbox)
-	const serviceProxy = createInvokeProxy(input.sandbox)
-	const streamProxy = createInvokeProxy(input.sandbox)
+): QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder> => {
+	const internalBuilder = builder as unknown as {
+		invokes: QueueWorkerContextMockBuilderTypes<TBuilder>['Invokes']
+		streamInvokes: QueueWorkerContextMockBuilderTypes<TBuilder>['StreamInvokes']
+		emitList: QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList']
+		queueInvokes: QueueInvokeList
+		agentInvokes: readonly unknown[]
+	}
+	const base = createBaseContextStubs<Resources, QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList']>(
+		internalBuilder.emitList as FromEmitToOtherType<QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList'], Schema>,
+		input.sandbox,
+	)
+	const serviceProxy = createInvokeProxy<QueueWorkerContextMockBuilderTypes<TBuilder>['Invokes']>(input.sandbox)
+	const streamProxy = createInvokeProxy<QueueWorkerContextMockBuilderTypes<TBuilder>['StreamInvokes']>(input.sandbox)
+	const agentProxy = createAgentInvokeProxy<QueueWorkerContextMockBuilderTypes<TBuilder>['AgentInvokes']>(input.sandbox)
 	const resourcesProxy = createResourceProxy(input.resources, base.stubs.resources)
 	const message = createQueueMessageMock(input)
 
@@ -126,12 +165,12 @@ export const createQueueWorkerContextMock = <
 	}
 	const abortController = new AbortController()
 
-	const context: QueueJobContext<Payload, Parameter, Resources> = {
+	const context: QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context'] = {
 		logger: base.logger.mock,
-		metrics: createMetricContextMock(input.sandbox),
+		metrics: createMetricContextMock<EmptyObject>(input.sandbox),
 		message,
 		signal: abortController.signal,
-		emit: async (_eventName, _payload) => undefined,
+		emit: async (eventName, payload) => base.stubs.emit[eventName](eventName, payload),
 		wrapInSpan: base.stubs.wrapInSpan.callsFake((name, opts, fn) => {
 			void name
 			void opts
@@ -161,9 +200,18 @@ export const createQueueWorkerContextMock = <
 			removeState: base.stubs.removeState.rejects(new Error('removeState is not stubbed')),
 		},
 		queue: {
-			enqueue: base.stubs.enqueue.rejects(new Error('enqueue is not stubbed')) as any,
-			scheduleAt: base.stubs.scheduleAt.rejects(new Error('scheduleAt is not stubbed')) as any,
+			enqueue: createQueueEnqueueProxy(
+				(async (queueName, payload, parameter, options) =>
+					base.stubs.enqueue(queueName, payload, parameter, options)) as QueueInvokeFunction,
+				internalBuilder.queueInvokes,
+			),
+			scheduleAt: createQueueScheduleProxy(
+				(async (queueName, runAt, payload, parameter, options) =>
+					base.stubs.scheduleAt(queueName, runAt, payload, parameter, options)) as QueueScheduleFunction,
+				internalBuilder.queueInvokes,
+			),
 		},
+		agent: agentProxy.api,
 		job: {
 			complete: async output => job.complete(output),
 			retry: async (request?: QueueRetryRequest) => job.retry(request),
@@ -180,7 +228,7 @@ export const createQueueWorkerContextMock = <
 		message,
 		stubs: {
 			logger: base.stubs.logger,
-			emit: base.stubs.emit as unknown as SinonStub,
+			emit: base.stubs.emit as FromEmitToOtherType<QueueWorkerContextMockBuilderTypes<TBuilder>['EmitList'], SinonStub>,
 			wrapInSpan: base.stubs.wrapInSpan,
 			startActiveSpan: base.stubs.startActiveSpan,
 			getSecret: base.stubs.getSecret,
@@ -194,8 +242,17 @@ export const createQueueWorkerContextMock = <
 			removeState: base.stubs.removeState,
 			resources: base.stubs.resources,
 			job,
-			service: serviceProxy.createApi<QueueJobContext<Payload, Parameter, Resources>['service']>(),
-			stream: streamProxy.createApi<QueueJobContext<Payload, Parameter, Resources>['stream']>(),
+			service:
+				serviceProxy.createApi<
+					QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context']['service']
+				>(),
+			stream:
+				streamProxy.createApi<
+					QueueWorkerContextMockResult<Payload, Parameter, Resources, TBuilder>['context']['stream']
+				>(),
+			agent: agentProxy.api,
+			enqueue: base.stubs.enqueue,
+			scheduleAt: base.stubs.scheduleAt,
 		},
 	}
 }

--- a/packages/core/src/testing/createQueueWorkerTestHarness.ts
+++ b/packages/core/src/testing/createQueueWorkerTestHarness.ts
@@ -26,7 +26,7 @@ export type InferQueueWorkerHarnessServiceBuilderConfig<T> = T extends ServiceBu
  */
 export const createQueueWorkerTestHarness = async <TServiceBuilder extends ServiceBuilder<ServiceBuilderTypes>>(
 	serviceBuilder: TServiceBuilder,
-	workerBuilder: QueueWorkerBuilder,
+	workerBuilder: QueueWorkerBuilder<any>,
 	options: InstanceConfigType<InferQueueWorkerHarnessServiceBuilderConfig<TServiceBuilder>> & {
 		eventBridge?: EventBridge
 		queueBridge?: QueueBridge

--- a/packages/core/src/testing/createQueueWorkerTestingHelpers.test.ts
+++ b/packages/core/src/testing/createQueueWorkerTestingHelpers.test.ts
@@ -32,6 +32,67 @@ describe('queue worker testing helpers', () => {
 		expect(mock.stubs.job.complete.firstCall.args[0]).toStrictEqual({ status: 'done' })
 	})
 
+	it('creates declared capability stubs for direct queue worker handler tests', async () => {
+		const serviceBuilder = new ServiceBuilder({
+			serviceName: 'WorkerService',
+			serviceVersion: '1',
+			serviceDescription: 'worker service',
+		})
+
+		const payloadSchema = z.object({ id: z.string() })
+		const parameterSchema = z.object({ tenantId: z.string() })
+		const outputSchema = z.object({ status: z.literal('ok') })
+
+		const workerBuilder = serviceBuilder
+			.getQueueWorkerBuilder('jobs', 'jobWorker')
+			.canInvoke('TicketService', '1', 'loadTicket', outputSchema, payloadSchema, parameterSchema)
+			.canEnqueue('auditQueue', payloadSchema, parameterSchema)
+			.canEmit('worker.done', z.object({ jobId: z.string() }))
+			.canInvokeAgent('triageTicket', '1', {
+				outputSchema,
+				payloadSchema,
+				parameterSchema,
+			})
+			.setHandler(async function (context) {
+				const payload = context.message.payload as { id: string }
+				const parameter = context.message.parameter as { tenantId: string }
+				const ticket = await context.service.TicketService['1'].loadTicket(
+					{ id: payload.id },
+					{ tenantId: parameter.tenantId },
+				)
+				await context.queue.enqueue.auditQueue({ id: payload.id }, { tenantId: parameter.tenantId })
+				await context.emit('worker.done', { jobId: context.message.id })
+				const agentResult = await context.agent['triageTicket.1'].run(
+					{ id: payload.id },
+					{ tenantId: parameter.tenantId },
+				)
+
+				expectTypeOf(ticket.status).toEqualTypeOf<'ok'>()
+				expectTypeOf(agentResult.status).toEqualTypeOf<'ok'>()
+
+				return { status: 'success' as const }
+			})
+
+		const mock = createQueueWorkerContextMock(workerBuilder, {
+			queueName: 'jobs',
+			payload: { id: '42' },
+			parameter: { tenantId: 'tenant-1' },
+		})
+		const service = mock.stubs.service as any
+		const agent = (mock.stubs as any).agent
+
+		service.TicketService['1'].loadTicket.resolves({ status: 'ok' })
+		agent['triageTicket.1'].run.resolves({ status: 'ok' })
+
+		const definition = await workerBuilder.getDefinition()
+		await definition.handler(mock.context as never, mock.message as never)
+
+		expect(service.TicketService['1'].loadTicket.calledOnce).toBe(true)
+		expect(mock.stubs.enqueue.calledOnce).toBe(true)
+		expect((mock.stubs.emit as any)['worker.done'].calledOnce).toBe(true)
+		expect(agent['triageTicket.1'].run.calledOnce).toBe(true)
+	})
+
 	it('executes one queue worker cycle through the runtime harness', async () => {
 		const serviceBuilder = new ServiceBuilder({
 			serviceName: 'HarnessWorkerService',
@@ -75,6 +136,72 @@ describe('queue worker testing helpers', () => {
 			expect(result.ackCalls).toHaveLength(1)
 			expect(result.deadLetterCalls).toHaveLength(0)
 			expect(result.nackCalls).toHaveLength(0)
+		} finally {
+			await harness.destroy()
+		}
+	})
+
+	it('passes declared worker capabilities into the runtime queue worker context', async () => {
+		const serviceBuilder = new ServiceBuilder({
+			serviceName: 'HarnessWorkerService',
+			serviceVersion: '1',
+			serviceDescription: 'worker harness service',
+		})
+
+		const payloadSchema = z.object({ id: z.string() })
+		const parameterSchema = z.object({ tenantId: z.string() })
+		const outputSchema = z.object({ status: z.literal('ok') })
+
+		const queueBuilder = serviceBuilder
+			.getQueueBuilder('jobs', 'job queue')
+			.addPayloadSchema(payloadSchema)
+			.addParameterSchema(parameterSchema)
+		const auditQueueBuilder = serviceBuilder
+			.getQueueBuilder('auditQueue', 'audit queue')
+			.addPayloadSchema(payloadSchema)
+			.addParameterSchema(parameterSchema)
+
+		const workerBuilder = serviceBuilder
+			.getQueueWorkerBuilder('jobs', 'jobWorker')
+			.canEnqueue('auditQueue', payloadSchema, parameterSchema)
+			.canInvokeAgent('triageTicket', '1', {
+				outputSchema,
+				payloadSchema,
+				parameterSchema,
+			})
+			.setHandler(async function (context) {
+				const payload = context.message.payload as { id: string }
+				const parameter = context.message.parameter as { tenantId: string }
+				await context.queue.enqueue.auditQueue({ id: payload.id }, { tenantId: parameter.tenantId })
+				const result = await context.agent['triageTicket.1'].run({ id: payload.id }, { tenantId: parameter.tenantId })
+				expect(result.status).toBe('ok')
+				return { status: 'success' as const }
+			})
+
+		serviceBuilder.addQueueDefinition(queueBuilder.getDefinition(), auditQueueBuilder.getDefinition())
+		serviceBuilder.addQueueWorkerDefinition(workerBuilder.getDefinition())
+
+		const harness = await createQueueWorkerTestHarness(serviceBuilder, workerBuilder)
+		harness.stubs.eventBridge?.invoke.resolves({ status: 'ok' })
+
+		try {
+			await harness.run({
+				id: 'job-capability',
+				queueName: 'jobs',
+				payload: { id: '42' },
+				parameter: { tenantId: 'tenant-1' },
+				headers: {},
+				createdAt: Date.now(),
+				attempt: 1,
+				maxAttempts: 3,
+				leaseExpiresAt: Date.now() + 60_000,
+				leaseTtlMs: 60_000,
+				traceId: 'trace-capability',
+				correlationId: 'corr-capability',
+			})
+
+			expect(harness.stubs.queueBridge?.enqueue.calledOnce).toBe(true)
+			expect(harness.stubs.eventBridge?.invoke.calledOnce).toBe(true)
 		} finally {
 			await harness.destroy()
 		}

--- a/packages/core/src/testing/sharedContextMocks.ts
+++ b/packages/core/src/testing/sharedContextMocks.ts
@@ -117,6 +117,35 @@ export const createInvokeProxy = <Invokes extends InvokeList | StreamInvokeList 
 	}
 }
 
+export const createAgentInvokeProxy = <AgentInvokes extends Record<string, unknown>>(sandbox?: SinonSandbox) => {
+	const agentMocks: Record<string, { run: SinonStub }> = {}
+
+	const api = new Proxy(
+		{},
+		{
+			get(_target: object, name) {
+				if (typeof name !== 'string' || name === 'then' || name === 'catch' || name === 'finally') {
+					return undefined
+				}
+
+				if (!agentMocks[name]) {
+					agentMocks[name] = {
+						run: sandbox?.stub() ?? stub(),
+					}
+					agentMocks[name].run.rejects(new Error(`agent invocation ${name} is not stubbed`))
+				}
+
+				return agentMocks[name]
+			},
+		},
+	) as AgentInvokes
+
+	return {
+		api,
+		stubs: agentMocks,
+	}
+}
+
 export const createEmitStubMap = <EmitList extends Record<string, Schema>>(
 	emitList: FromEmitToOtherType<EmitList, Schema>,
 	sandbox?: SinonSandbox,

--- a/packages/dapr-sdk/package.json
+++ b/packages/dapr-sdk/package.json
@@ -43,7 +43,7 @@
 		"@types/sinon": "^21.0.1",
 		"hono": "^4.12.23",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/gcloud-secret-store/package.json
+++ b/packages/gcloud-secret-store/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@google-cloud/secret-manager": "^6.1.2",

--- a/packages/hono-http-server/package.json
+++ b/packages/hono-http-server/package.json
@@ -37,7 +37,7 @@
 		"@types/sinon": "^21.0.1",
 		"@hono/swagger-ui": "^0.6.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/infisical-secret-store/package.json
+++ b/packages/infisical-secret-store/package.json
@@ -38,7 +38,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*"

--- a/packages/k8s-sdk/package.json
+++ b/packages/k8s-sdk/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/mqttbridge/package.json
+++ b/packages/mqttbridge/package.json
@@ -37,7 +37,7 @@
 		"@types/sinon": "^21.0.1",
 		"@types/ws": "^8.18.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/nats-config-store/package.json
+++ b/packages/nats-config-store/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/nats-queue-bridge/package.json
+++ b/packages/nats-queue-bridge/package.json
@@ -35,7 +35,7 @@
 	"devDependencies": {
 		"@testcontainers/nats": "^12.0.1",
 		"@types/node": "^25.9.1",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/nats-state-store/package.json
+++ b/packages/nats-state-store/package.json
@@ -37,7 +37,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/natsbridge/package.json
+++ b/packages/natsbridge/package.json
@@ -38,7 +38,7 @@
 		"@types/sinon": "^21.0.1",
 		"@types/ws": "^8.18.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/packages/redis-config-store/package.json
+++ b/packages/redis-config-store/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/redis-queue-bridge/package.json
+++ b/packages/redis-queue-bridge/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/redis-state-store/package.json
+++ b/packages/redis-state-store/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "^25.9.1",
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/packages/vault-secret-store/package.json
+++ b/packages/vault-secret-store/package.json
@@ -37,7 +37,7 @@
 		"@types/sinon": "^21.0.1",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.1",
-		"vitest": "^4.1.7"
+		"vitest": "^4.1.8"
 	},
 	"dependencies": {
 		"@purista/core": "*",

--- a/skills/purista/SKILL.md
+++ b/skills/purista/SKILL.md
@@ -29,6 +29,7 @@ Do not blur these layers. Most mistakes come from designing routes, prompts, or 
 - Keep external systems behind resources or runtime bindings.
 - Treat tenant isolation, authorization, auditability, and data minimization as architecture requirements, not handler details.
 - Do not leak secrets, PII, prompts, completions, tokens, raw payloads, headers, or attachments into logs, metrics, traces, events, generated examples, or model calls unless an explicit product policy allows the exact field.
+- Declare handler capabilities before use. Commands, streams, subscriptions, queue workers, and agents should access other components through typed context surfaces produced by `.canInvoke(...)`, `.canConsumeStream(...)`, `.canEnqueue(...)`, `.canEmit(...)`, and agent-specific declarations where available.
 - Keep EventBridge and QueueBridge separate. Event transports do not become queues.
 - Agents are native `@purista/core` builder/runtime primitives backed by `@purista/harness`; provider packages remain app-level dependencies.
 - Use Hono as the active HTTP server package. Do not revive legacy HTTP server guidance.
@@ -83,6 +84,7 @@ PURISTA records agent wrapper metrics only. `@purista/harness` owns GenAI semant
 ## Verification Cues
 - The design can name one owner for each capability and source of truth.
 - Every handler dependency is reachable through resources, stores, context, or declared runtime bindings.
+- Queue workers declare every service, stream, queue, event, and same-service agent dependency before using `context.service`, `context.stream`, `context.queue`, `context.emit`, or `context.agent`.
 - Runtime wiring names required bridges, stores, providers, telemetry, queue bridges, and HTTP servers.
 - Metrics wiring names the app-owned OpenTelemetry provider/exporters and keeps Prometheus outside core.
 - Handler code uses declared custom metrics through typed `context.metrics`, not raw metric names or a raw recorder.

--- a/skills/purista/references/02-implementation-workflow.md
+++ b/skills/purista/references/02-implementation-workflow.md
@@ -60,7 +60,7 @@ Generated artifacts should remain explicit:
 - schema definitions live beside the boundary
 - boundary schemas contain the minimum data needed by that boundary
 - `setBeforeGuardHooks(...)` enforces tenant/principal preconditions before handler logic for sensitive operations
-- handlers use `context.resources`, `context.service`, `context.stream`, `context.queue`, or `context.harness`
+- handlers use `context.resources`, `context.service`, `context.stream`, `context.queue`, `context.emit`, `context.agent`, or `context.harness` only after the corresponding builder capability has been declared
 - runtime clients are not created inside handlers
 - service files add definitions via service builder methods
 - logs, metrics, traces, events, queue payloads, streams, and prompts do not include secrets, PII, raw headers, tokens, or full request bodies by default

--- a/skills/purista/references/03-component-builders.md
+++ b/skills/purista/references/03-component-builders.md
@@ -64,6 +64,31 @@ npm run add:queue-worker -- invoiceProcessor --service billing --service-version
 
 Use queue-backed execution when work needs leases, retries, delay, dead-letter handling, or operator replay.
 
+Queue workers use the same declared dependency model as other handlers. Declare dependencies before the worker function so the runtime manifest, handler context, and test helpers stay typed and auditable:
+
+```ts
+const worker = service
+	.getQueueWorkerBuilder('invoiceProcessing', 'Processes invoice jobs')
+	.canInvoke('InvoiceService', '1', 'sendInvoice', sendInvoiceOutputSchema, invoicePayloadSchema)
+	.canConsumeStream('InvoiceService', '1', 'renderInvoice', invoiceChunkSchema, invoicePayloadSchema)
+	.canEnqueue('notificationQueue', notificationPayloadSchema, notificationParameterSchema)
+	.canEmit('invoice.completed', invoiceCompletedEventSchema)
+	.canInvokeAgent('reconcileInvoice', '1', {
+		outputSchema: reconcileOutputSchema,
+		payloadSchema: reconcilePayloadSchema,
+		parameterSchema: reconcileParameterSchema,
+	})
+	.setHandler(async function (context) {
+		const payload = context.message.payload as { invoiceId: string }
+		await context.service.InvoiceService['1'].sendInvoice({ invoiceId: payload.invoiceId })
+		await context.queue.enqueue.notificationQueue({ invoiceId: payload.invoiceId })
+		await context.emit('invoice.completed', { invoiceId: payload.invoiceId })
+		await context.agent['reconcileInvoice.1'].run({ invoiceId: payload.invoiceId })
+	})
+```
+
+Use `canInvokeAgent(...)` only for agents attached to the same service. Cross-service AI work should go through explicit command, stream, queue, or event contracts.
+
 ## Schedules
 Use schedules to declare external time-trigger intent. Schedules do not run inside PURISTA.
 

--- a/skills/purista/references/07-testing-observability-and-deployment.md
+++ b/skills/purista/references/07-testing-observability-and-deployment.md
@@ -7,7 +7,7 @@ Test declared boundaries and runtime wiring:
 - command tests should use command context helpers or service instances
 - subscription tests should assert consumed event behavior
 - stream tests should verify chunks and final payloads
-- queue worker tests should cover retry/ack/dead-letter behavior when relevant
+- queue worker tests should assert declared `canInvoke`, `canConsumeStream`, `canEnqueue`, `canEmit`, and `canInvokeAgent` dependencies through the queue worker context helpers, plus retry/ack/dead-letter behavior when relevant
 - schedule export tests should assert deterministic manifests and unsupported expression failures without a live scheduler or cluster
 - strict queue idempotency tests should assert duplicate enqueue returns the original job id and does not create a second job
 - agent tests should use core agent testing helpers

--- a/web/package.json
+++ b/web/package.json
@@ -15,30 +15,30 @@
 	},
 	"dependencies": {
 		"@astrojs/mdx": "^6.0.1",
-		"@astrojs/react": "^5.0.6",
+		"@astrojs/react": "^5.0.7",
 		"@fontsource/inter": "^5.2.8",
 		"@sebastianwessel/isostate": "^0.4.0",
-		"@shikijs/transformers": "^4.1.0",
+		"@shikijs/transformers": "^4.2.0",
 		"@tailwindcss/vite": "^4.3.0",
 		"@types/gsap": "^3.0.0",
-		"@types/react": "^19.2.15",
+		"@types/react": "^19.2.16",
 		"@types/react-dom": "^19.2.3",
 		"@types/three": "^0.184.1",
-		"@xyflow/react": "^12.10.2",
-		"astro": "^6.4.2",
+		"@xyflow/react": "^12.11.0",
+		"astro": "^6.4.3",
 		"astro-og-canvas": "^0.11.1",
 		"beautiful-mermaid": "^1.1.3",
 		"gsap": "^3.15.0",
 		"lenis": "^1.3.23",
 		"mermaid": "^11.15.0",
-		"react": "^19.2.6",
-		"react-dom": "^19.2.6",
-		"shiki": "^4.1.0",
+		"react": "^19.2.7",
+		"react-dom": "^19.2.7",
+		"shiki": "^4.2.0",
 		"tailwindcss": "^4.3.0",
 		"three": "^0.184.0"
 	},
 	"devDependencies": {
 		"@sebastianwessel/isostate-cli": "^0.4.0",
-		"vite": "^8.0.14"
+		"vite": "^7.3.5"
 	}
 }

--- a/web/src/content/handbook/2_building_business-logic/queue/test-a-queue-worker.md
+++ b/web/src/content/handbook/2_building_business-logic/queue/test-a-queue-worker.md
@@ -35,6 +35,25 @@ Use this level when you want to verify:
 - job completion or retry logic
 - resource usage
 - handler branching
+- declared outbound calls through `mock.stubs.service`, `mock.stubs.stream`, `mock.stubs.enqueue`, `mock.stubs.emit`, and `mock.stubs.agent`
+
+For example, if a worker declares `.canEnqueue('auditJob', ...)` and `.canInvokeAgent('triagePing', '1', ...)`, the context mock exposes matching helpers:
+
+```ts
+const mock = createQueueWorkerContextMock(processJobWorkerBuilder, {
+  queueName: 'pingJob',
+  payload: { ping: 'queued ping' },
+  parameter: { requestId: 'req-1' },
+})
+
+mock.stubs.agent['triagePing.1'].run.resolves({ priority: 'normal' })
+
+const definition = await processJobWorkerBuilder.getDefinition()
+await definition.handler(mock.context, mock.message)
+
+expect(mock.stubs.enqueue.calledWith('auditJob')).toBe(true)
+expect(mock.stubs.agent['triagePing.1'].run.calledOnce).toBe(true)
+```
 
 ## Runtime test
 

--- a/web/src/content/handbook/2_building_business-logic/queue/the-queue-worker-builder.md
+++ b/web/src/content/handbook/2_building_business-logic/queue/the-queue-worker-builder.md
@@ -48,6 +48,34 @@ Inside the handler you receive:
 
 All helpers emit OpenTelemetry spans so you get timing and failure statistics automatically.
 
+## Outbound capabilities
+
+Queue workers can call other PURISTA boundaries, but those calls should be declared on the worker builder so the handler context is typed and test helpers can expose matching stubs.
+
+```ts
+export const processJobWorkerBuilder = pingV1ServiceBuilder
+  .getQueueWorkerBuilder('pingJob', 'Process queued pings')
+  .canInvoke('NotificationService', '1', 'sendEmail', sendEmailOutputSchema, sendEmailPayloadSchema)
+  .canConsumeStream('ReportService', '1', 'exportReport', reportChunkSchema, reportPayloadSchema)
+  .canEnqueue('auditJob', auditPayloadSchema, auditParameterSchema)
+  .canEmit('ping.processed', pingProcessedEventSchema)
+  .canInvokeAgent('triagePing', '1', {
+    outputSchema: triageOutputSchema,
+    payloadSchema: triagePayloadSchema,
+    parameterSchema: triageParameterSchema,
+  })
+  .setHandler(async function (context) {
+    await context.service.NotificationService['1'].sendEmail({ id: context.message.id })
+    await context.queue.enqueue.auditJob({ id: context.message.id })
+    await context.emit('ping.processed', { jobId: context.message.id })
+    const triage = await context.agent['triagePing.1'].run({ jobId: context.message.id })
+
+    return { status: 'success', output: triage }
+  })
+```
+
+Use `.canInvokeAgent(...)` for agents attached to the same service. For agents owned by another service, expose and call the generated agent command with `.canInvoke(...)`.
+
 ## Error handling
 
 Unhandled exceptions trigger `context.job.retry()` automatically until `maxAttempts` is exceeded. Use `HandledError` to control the reason/status stored alongside the job. For critical failures, call `context.job.moveToDeadLetter()` yourself to bypass retries.


### PR DESCRIPTION
## Summary

Adds declared capability support to queue workers so worker handlers can use typed context access for service invocations, stream consumption, queue enqueueing, event emission, and same-service agent invocation.

This also updates queue worker test helpers to derive typed stubs from worker metadata, refreshes the queue worker handbook pages, updates the canonical `purista/skills` guidance, and bumps workspace dependencies across the purista monorepo and examples.

## Root cause

Queue workers did not expose the same `.can*` declaration flow as other PURISTA builders, so runtime context wiring and test helper mocks had no typed metadata for worker-side dependencies. The shared PURISTA skill also needed to teach the new queue worker capability model so downstream agent guidance does not drift from the implementation.

## Notes

- Vite is kept on `7.3.5` because stable `astro@6.4.3` depends on `vite@^7.3.2`; Vite 8 caused the Astro/Tailwind build to fail in the Vite/Rolldown resolver path.
- `npm install` in the local Node 26 environment required `--engine-strict=false` because `cloudevents@10.0.0` declares Node support through Node 24.
- `npm audit` still reports force-only fixes for Temporal/protobufjs and CloudEvents/uuid; I did not apply `npm audit fix --force` because npm reports breaking/downgrade changes.

## Verification

- `npm run test:unit`
- `npm run build -w @purista/web`
- `npm run deps:check`
- `git diff --check`
- `npm run audit:skills`
- `npm run audit:knowledge`
- focused queue worker builder/helper tests
- `npx tsc --noEmit -p ./tsconfig.unit.json`
