### PR TITLE
chore: update dependencies

### DIFF
--- a/examples/agent-example/package.json
+++ b/examples/agent-example/package.json
@@ -22,18 +22,18 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
 		"@purista/harness-openai": "^1.7.0",
 		"@purista/hono-http-server": "*",
-		"@scalar/hono-api-reference": "^0.11.8",
+		"@scalar/hono-api-reference": "^0.11.11",
 		"dotenv": "^17.4.2",
 		"zod": "^4.4.3"
 	}

--- a/examples/client-builder/package.json
+++ b/examples/client-builder/package.json
@@ -20,20 +20,20 @@
 		"client:code": "tsx src/generateClientFromCode.ts"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
-		"@scalar/hono-api-reference": "^0.11.8"
+		"@scalar/hono-api-reference": "^0.11.11"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.2",
+		"@biomejs/biome": "^2.5.4",
 		"@purista/cli": "*",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},

--- a/examples/dapr-example/package.json
+++ b/examples/dapr-example/package.json
@@ -21,16 +21,16 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@opentelemetry/exporter-zipkin": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
 		"@purista/core": "*",

--- a/examples/enterprise-billing-cycle/package.json
+++ b/examples/enterprise-billing-cycle/package.json
@@ -20,9 +20,9 @@
 		"test": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2"
 	},
 	"dependencies": {

--- a/examples/fullexample/package.json
+++ b/examples/fullexample/package.json
@@ -39,15 +39,15 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",

--- a/examples/hono-example/package.json
+++ b/examples/hono-example/package.json
@@ -22,21 +22,21 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/sdk-metrics": "^2.9.0",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
-		"@scalar/hono-api-reference": "^0.11.8",
+		"@scalar/hono-api-reference": "^0.11.11",
 		"zod": "^4.4.3"
 	}
 }

--- a/examples/kubernetes/package.json
+++ b/examples/kubernetes/package.json
@@ -21,16 +21,16 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
 		"@purista/amqpbridge": "*",

--- a/examples/metrics/package.json
+++ b/examples/metrics/package.json
@@ -21,9 +21,9 @@
 		"test": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2"
 	},
 	"dependencies": {

--- a/examples/mqtt-bridge/package.json
+++ b/examples/mqtt-bridge/package.json
@@ -23,16 +23,16 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
 		"@purista/mqttbridge": "*",

--- a/examples/nats-bridge/package.json
+++ b/examples/nats-bridge/package.json
@@ -23,16 +23,16 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
 		"@purista/nats-state-store": "*",

--- a/examples/quickstart/package.json
+++ b/examples/quickstart/package.json
@@ -21,16 +21,16 @@
 		"test": "tsc --noEmit && vitest"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
 		"zod": "^4.4.3"

--- a/examples/temporal/package.json
+++ b/examples/temporal/package.json
@@ -18,29 +18,29 @@
 		"purista": "purista add"
 	},
 	"dependencies": {
-		"@hono/node-server": "^2.0.8",
+		"@hono/node-server": "^2.0.10",
 		"@hono/swagger-ui": "^0.6.1",
 		"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
 		"@opentelemetry/sdk-node": "^0.220.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
 		"@purista/hono-http-server": "*",
 		"@purista/natsbridge": "*",
-		"@temporalio/activity": "^1.20.0",
-		"@temporalio/client": "^1.20.0",
-		"@temporalio/interceptors-opentelemetry": "^1.20.0",
-		"@temporalio/worker": "^1.20.0",
-		"@temporalio/workflow": "^1.20.0",
+		"@temporalio/activity": "^1.20.3",
+		"@temporalio/client": "^1.20.3",
+		"@temporalio/interceptors-opentelemetry": "^1.20.3",
+		"@temporalio/worker": "^1.20.3",
+		"@temporalio/workflow": "^1.20.3",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"pino-pretty": "^13.1.3",
 		"sinon": "^22.0.0",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "codex-migrate-typescript-7",
+	"name": "@purista/purista",
 	"version": "3.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
@@ -12,8 +12,8 @@
 				"web"
 			],
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.2",
-				"@types/node": "^26.1.0",
+				"@biomejs/biome": "^2.5.4",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"@vitest/coverage-v8": "^4.1.10",
@@ -24,7 +24,7 @@
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.4",
 				"ts-node": "^10.9.2",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typedoc": "^0.28.20",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
@@ -38,18 +38,18 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
 				"@purista/harness-openai": "^1.7.0",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.11.8",
+				"@scalar/hono-api-reference": "^0.11.11",
 				"dotenv": "^17.4.2",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -60,20 +60,20 @@
 		"examples/client-builder": {
 			"version": "3.2.2",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.11.8"
+				"@scalar/hono-api-reference": "^0.11.11"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.5.2",
+				"@biomejs/biome": "^2.5.4",
 				"@purista/cli": "*",
 				"@types/jest": "^30.0.0",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -86,7 +86,7 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@opentelemetry/exporter-zipkin": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
 				"@purista/core": "*",
@@ -94,11 +94,11 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -115,9 +115,9 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2"
 			},
 			"engines": {
@@ -129,7 +129,7 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/exporter-metrics-otlp-http": "^0.220.0",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
@@ -145,10 +145,10 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -161,20 +161,20 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/sdk-metrics": "^2.9.0",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
-				"@scalar/hono-api-reference": "^0.11.8",
+				"@scalar/hono-api-reference": "^0.11.11",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -187,7 +187,7 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
 				"@purista/amqpbridge": "*",
@@ -196,11 +196,11 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -219,9 +219,9 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2"
 			},
 			"engines": {
@@ -233,18 +233,18 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
 				"@purista/mqttbridge": "*",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -257,7 +257,7 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
 				"@purista/nats-state-store": "*",
@@ -265,11 +265,11 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -282,17 +282,17 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
@@ -304,169 +304,34 @@
 			"name": "@purista/temporal-example",
 			"version": "3.2.2",
 			"dependencies": {
-				"@hono/node-server": "^2.0.8",
+				"@hono/node-server": "^2.0.10",
 				"@hono/swagger-ui": "^0.6.1",
 				"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
 				"@opentelemetry/sdk-node": "^0.220.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
 				"@purista/hono-http-server": "*",
 				"@purista/natsbridge": "*",
-				"@temporalio/activity": "^1.20.0",
-				"@temporalio/client": "^1.20.0",
-				"@temporalio/interceptors-opentelemetry": "^1.20.0",
-				"@temporalio/worker": "^1.20.0",
-				"@temporalio/workflow": "^1.20.0",
+				"@temporalio/activity": "^1.20.3",
+				"@temporalio/client": "^1.20.3",
+				"@temporalio/interceptors-opentelemetry": "^1.20.3",
+				"@temporalio/worker": "^1.20.3",
+				"@temporalio/workflow": "^1.20.3",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@typescript/native": "npm:typescript@^7.0.2",
 				"pino-pretty": "^13.1.3",
 				"sinon": "^22.0.0",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"typescript": "npm:@typescript/typescript6@^6.0.2",
 				"vitest": "^4.1.10"
 			},
 			"engines": {
 				"node": ">=24.15.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/resources": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"examples/temporal/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.20.0",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/interceptors-opentelemetry": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/interceptors-opentelemetry/-/interceptors-opentelemetry-1.20.0.tgz",
-			"integrity": "sha512-jKy2BqW2WNEwXwoosIBe2E+vRdFL4kY2591k7nU/0746mxpKiDYDM9WpQUbyvMt3IQliQQ3+Nk9pj8/9H6Q+iQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@opentelemetry/api": "^1.9.0",
-				"@opentelemetry/core": "^1.25.1",
-				"@opentelemetry/resources": "^1.25.1",
-				"@opentelemetry/sdk-trace-base": "^1.25.1",
-				"@temporalio/plugin": "1.20.0"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			},
-			"peerDependencies": {
-				"@temporalio/common": "1.20.0",
-				"@temporalio/workflow": "1.20.0"
-			},
-			"peerDependenciesMeta": {
-				"@temporalio/workflow": {
-					"optional": true
-				}
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/plugin": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.20.0.tgz",
-			"integrity": "sha512-GdTSDP6vpSHbetG/hyMJKGbA0uCCr+/VeZlEFNsVfxDYie/+3wsirgQpQ+5ore8/BGKgmY2NXoWtjhIQxMf6QA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "^7.6.4"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"examples/temporal/node_modules/@temporalio/workflow": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.20.0.tgz",
-			"integrity": "sha512-L10zSOW+6WCiI+0a679P58ib9nXAuNeME/Pr23djWzrXy1zQh9apUlyp4UCaLzdcaaXURqWMWUhNc31/RvRThw==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/common": "1.20.0",
-				"@temporalio/proto": "1.20.0",
-				"nexus-rpc": "^0.0.2"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"examples/temporal/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -483,29 +348,29 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.0.tgz",
-			"integrity": "sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
+			"integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
 			"license": "MIT",
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@astrojs/compiler-binding-darwin-arm64": "0.3.0",
-				"@astrojs/compiler-binding-darwin-x64": "0.3.0",
-				"@astrojs/compiler-binding-linux-arm64-gnu": "0.3.0",
-				"@astrojs/compiler-binding-linux-arm64-musl": "0.3.0",
-				"@astrojs/compiler-binding-linux-x64-gnu": "0.3.0",
-				"@astrojs/compiler-binding-linux-x64-musl": "0.3.0",
-				"@astrojs/compiler-binding-wasm32-wasi": "0.3.0",
-				"@astrojs/compiler-binding-win32-arm64-msvc": "0.3.0",
-				"@astrojs/compiler-binding-win32-x64-msvc": "0.3.0"
+				"@astrojs/compiler-binding-darwin-arm64": "0.3.1",
+				"@astrojs/compiler-binding-darwin-x64": "0.3.1",
+				"@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
+				"@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
+				"@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
+				"@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
+				"@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
+				"@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
+				"@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-darwin-arm64": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.0.tgz",
-			"integrity": "sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
+			"integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
 			"cpu": [
 				"arm64"
 			],
@@ -519,9 +384,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-darwin-x64": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.0.tgz",
-			"integrity": "sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
+			"integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -535,9 +400,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.0.tgz",
-			"integrity": "sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
+			"integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -554,9 +419,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.0.tgz",
-			"integrity": "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
+			"integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -573,9 +438,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.0.tgz",
-			"integrity": "sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
+			"integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
 			"cpu": [
 				"x64"
 			],
@@ -592,9 +457,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.0.tgz",
-			"integrity": "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
+			"integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
 			"cpu": [
 				"x64"
 			],
@@ -611,9 +476,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.0.tgz",
-			"integrity": "sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
+			"integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
 			"cpu": [
 				"wasm32"
 			],
@@ -627,9 +492,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.0.tgz",
-			"integrity": "sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
+			"integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -643,9 +508,9 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.0.tgz",
-			"integrity": "sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
+			"integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
 			"cpu": [
 				"x64"
 			],
@@ -659,12 +524,12 @@
 			}
 		},
 		"node_modules/@astrojs/compiler-rs": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.0.tgz",
-			"integrity": "sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
+			"integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/compiler-binding": "0.3.0"
+				"@astrojs/compiler-binding": "0.3.1"
 			},
 			"engines": {
 				"node": ">=22.12.0"
@@ -724,15 +589,50 @@
 			}
 		},
 		"node_modules/@astrojs/markdown-satteri": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.3.tgz",
-			"integrity": "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+			"integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/internal-helpers": "0.10.1",
 				"@astrojs/prism": "4.0.2",
 				"github-slugger": "^2.0.0",
+				"hast-util-from-html": "^2.0.3",
 				"satteri": "^0.9.1"
+			}
+		},
+		"node_modules/@astrojs/mdx": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
+			"integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/internal-helpers": "0.10.1",
+				"@astrojs/markdown-remark": "7.2.1",
+				"@mdx-js/mdx": "^3.1.1",
+				"acorn": "^8.16.0",
+				"es-module-lexer": "^2.0.0",
+				"estree-util-visit": "^2.0.0",
+				"hast-util-to-html": "^9.0.5",
+				"piccolore": "^0.1.3",
+				"rehype-raw": "^7.0.0",
+				"remark-gfm": "^4.0.1",
+				"remark-smartypants": "^3.0.2",
+				"source-map": "^0.7.6",
+				"unist-util-visit": "^5.1.0",
+				"vfile": "^6.0.3"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			},
+			"peerDependencies": {
+				"@astrojs/markdown-satteri": "^0.3.1",
+				"astro": "^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@astrojs/markdown-satteri": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@astrojs/prism": {
@@ -770,16 +670,15 @@
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
-			"integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+			"integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ci-info": "^4.4.0",
 				"dset": "^3.1.4",
 				"is-docker": "^4.0.0",
-				"is-wsl": "^3.1.1",
-				"which-pm-runs": "^1.1.0"
+				"package-manager-detector": "^1.6.0"
 			},
 			"engines": {
 				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
@@ -801,18 +700,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-secrets-manager": {
-			"version": "3.1081.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1081.0.tgz",
-			"integrity": "sha512-rPLag4HuZYW/vCUMGZ19zFWgi8Uw/rARgxSLmPpX2ua9h1ysXX+KBwf4/o74uJO5qanVPHJv59aZ03/WBVrQKw==",
+			"version": "3.1090.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1090.0.tgz",
+			"integrity": "sha512-FUNb9Uf0GO3obl4ndos2Rtg/kUj0jkNIgZ0KorV67PlHmXWUs6lxH87Nck8dIJZgcigDrNRk74wf9xzbemcNGQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/credential-provider-node": "^3.972.64",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/fetch-http-handler": "^5.6.2",
-				"@smithy/node-http-handler": "^4.9.2",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/credential-provider-node": "^3.972.70",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -820,18 +719,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ssm": {
-			"version": "3.1081.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1081.0.tgz",
-			"integrity": "sha512-pgKETowK134GMnSLvh4uuqQejfrxTRRBsekwRVYsPKyyeHvt0PhZfea90lKwj3Af1Fre9xJ7oWnxfOUCnVdQTA==",
+			"version": "3.1090.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1090.0.tgz",
+			"integrity": "sha512-8nYV/qnr+lr+xcsLBzx4iFWsl1zIT8Uf9uS2xevpfuFM0BT6IIIisAuxrotr7Rng3YgqDRx78JZKNp87iR+7uA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/credential-provider-node": "^3.972.64",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/fetch-http-handler": "^5.6.2",
-				"@smithy/node-http-handler": "^4.9.2",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/credential-provider-node": "^3.972.70",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -839,17 +738,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.29.tgz",
-			"integrity": "sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==",
+			"version": "3.975.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+			"integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.15",
-				"@aws-sdk/xml-builder": "^3.972.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.36",
 				"@aws/lambda-invoke-store": "^0.3.0",
-				"@smithy/core": "^3.29.0",
-				"@smithy/signature-v4": "^5.6.1",
-				"@smithy/types": "^4.15.1",
+				"@smithy/core": "^3.29.4",
+				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/types": "^4.16.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
@@ -858,15 +757,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.55.tgz",
-			"integrity": "sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==",
+			"version": "3.972.59",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+			"integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -874,17 +773,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.57",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.57.tgz",
-			"integrity": "sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==",
+			"version": "3.972.61",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+			"integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/fetch-http-handler": "^5.6.2",
-				"@smithy/node-http-handler": "^4.9.2",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -892,23 +791,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.62",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.62.tgz",
-			"integrity": "sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==",
+			"version": "3.973.4",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+			"integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/credential-provider-env": "^3.972.55",
-				"@aws-sdk/credential-provider-http": "^3.972.57",
-				"@aws-sdk/credential-provider-login": "^3.972.61",
-				"@aws-sdk/credential-provider-process": "^3.972.55",
-				"@aws-sdk/credential-provider-sso": "^3.972.61",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.61",
-				"@aws-sdk/nested-clients": "^3.997.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/credential-provider-imds": "^4.4.5",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/credential-provider-env": "^3.972.59",
+				"@aws-sdk/credential-provider-http": "^3.972.61",
+				"@aws-sdk/credential-provider-login": "^3.972.66",
+				"@aws-sdk/credential-provider-process": "^3.972.59",
+				"@aws-sdk/credential-provider-sso": "^3.973.3",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/credential-provider-imds": "^4.4.9",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -916,16 +815,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.61",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.61.tgz",
-			"integrity": "sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==",
+			"version": "3.972.66",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+			"integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/nested-clients": "^3.997.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -933,21 +832,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.64",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.64.tgz",
-			"integrity": "sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==",
+			"version": "3.972.70",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+			"integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.55",
-				"@aws-sdk/credential-provider-http": "^3.972.57",
-				"@aws-sdk/credential-provider-ini": "^3.972.62",
-				"@aws-sdk/credential-provider-process": "^3.972.55",
-				"@aws-sdk/credential-provider-sso": "^3.972.61",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.61",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/credential-provider-imds": "^4.4.5",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/credential-provider-env": "^3.972.59",
+				"@aws-sdk/credential-provider-http": "^3.972.61",
+				"@aws-sdk/credential-provider-ini": "^3.973.4",
+				"@aws-sdk/credential-provider-process": "^3.972.59",
+				"@aws-sdk/credential-provider-sso": "^3.973.3",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.65",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/credential-provider-imds": "^4.4.9",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -955,15 +854,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.55",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.55.tgz",
-			"integrity": "sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==",
+			"version": "3.972.59",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+			"integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -971,17 +870,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.61",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.61.tgz",
-			"integrity": "sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==",
+			"version": "3.973.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+			"integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/nested-clients": "^3.997.29",
-				"@aws-sdk/token-providers": "3.1081.0",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/token-providers": "3.1088.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -989,16 +888,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.61",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.61.tgz",
-			"integrity": "sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==",
+			"version": "3.972.65",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+			"integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/nested-clients": "^3.997.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1006,18 +905,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.29.tgz",
-			"integrity": "sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==",
+			"version": "3.997.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+			"integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.38",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/fetch-http-handler": "^5.6.2",
-				"@smithy/node-http-handler": "^4.9.2",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/fetch-http-handler": "^5.6.6",
+				"@smithy/node-http-handler": "^4.9.6",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1025,14 +924,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
-			"integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+			"version": "3.996.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+			"integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/signature-v4": "^5.6.1",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1040,16 +939,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1081.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1081.0.tgz",
-			"integrity": "sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==",
+			"version": "3.1088.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+			"integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.29",
-				"@aws-sdk/nested-clients": "^3.997.29",
-				"@aws-sdk/types": "^3.973.15",
-				"@smithy/core": "^3.29.0",
-				"@smithy/types": "^4.15.1",
+				"@aws-sdk/core": "^3.975.3",
+				"@aws-sdk/nested-clients": "^3.997.33",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.29.4",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1057,12 +956,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
-			"integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+			"version": "3.974.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.15.1",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1070,12 +969,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-			"integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+			"integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.15.1",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1656,9 +1555,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.2.tgz",
-			"integrity": "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.4.tgz",
+			"integrity": "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -1672,20 +1571,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.5.2",
-				"@biomejs/cli-darwin-x64": "2.5.2",
-				"@biomejs/cli-linux-arm64": "2.5.2",
-				"@biomejs/cli-linux-arm64-musl": "2.5.2",
-				"@biomejs/cli-linux-x64": "2.5.2",
-				"@biomejs/cli-linux-x64-musl": "2.5.2",
-				"@biomejs/cli-win32-arm64": "2.5.2",
-				"@biomejs/cli-win32-x64": "2.5.2"
+				"@biomejs/cli-darwin-arm64": "2.5.4",
+				"@biomejs/cli-darwin-x64": "2.5.4",
+				"@biomejs/cli-linux-arm64": "2.5.4",
+				"@biomejs/cli-linux-arm64-musl": "2.5.4",
+				"@biomejs/cli-linux-x64": "2.5.4",
+				"@biomejs/cli-linux-x64-musl": "2.5.4",
+				"@biomejs/cli-win32-arm64": "2.5.4",
+				"@biomejs/cli-win32-x64": "2.5.4"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.2.tgz",
-			"integrity": "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.4.tgz",
+			"integrity": "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1700,9 +1599,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.2.tgz",
-			"integrity": "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.4.tgz",
+			"integrity": "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1717,9 +1616,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.2.tgz",
-			"integrity": "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.4.tgz",
+			"integrity": "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1737,9 +1636,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.2.tgz",
-			"integrity": "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.4.tgz",
+			"integrity": "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1757,9 +1656,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.2.tgz",
-			"integrity": "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.4.tgz",
+			"integrity": "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1777,9 +1676,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.2.tgz",
-			"integrity": "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.4.tgz",
+			"integrity": "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==",
 			"cpu": [
 				"x64"
 			],
@@ -1797,9 +1696,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.2.tgz",
-			"integrity": "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.4.tgz",
+			"integrity": "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1814,9 +1713,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.2.tgz",
-			"integrity": "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.4.tgz",
+			"integrity": "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==",
 			"cpu": [
 				"x64"
 			],
@@ -2485,9 +2384,9 @@
 			}
 		},
 		"node_modules/@fontsource/inter": {
-			"version": "5.2.8",
-			"resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
-			"integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.3.0.tgz",
+			"integrity": "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==",
 			"license": "OFL-1.1",
 			"funding": {
 				"url": "https://github.com/sponsors/ayuhito"
@@ -2570,9 +2469,9 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.8.tgz",
-			"integrity": "sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+			"integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -4636,9 +4535,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
-			"integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -5237,35 +5136,35 @@
 			}
 		},
 		"node_modules/@scalar/client-side-rendering": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.1.tgz",
-			"integrity": "sha512-V9pBpA5j59wCDfYeKQ/mSGc1M5YnOAc/aU0D3KVkvsZpSvlGuig5RW7Q8EeohtES4acZKq0KhVB+Rxx/GT58LA==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.3.4.tgz",
+			"integrity": "sha512-kb3B+FGjvAUr2DU0fe9dVKBLwot1TjOO+iHCTmY8r8FUJySmYKGQYCicRzzilOyTjvKspiZBCEr03PWaWW+1gw==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/schemas": "0.7.1",
-				"@scalar/types": "0.16.1",
-				"@scalar/validation": "0.6.0"
+				"@scalar/schemas": "0.7.4",
+				"@scalar/types": "0.16.4",
+				"@scalar/validation": "0.6.2"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@scalar/helpers": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.0.tgz",
-			"integrity": "sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==",
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.2.tgz",
+			"integrity": "sha512-hjyMpMZjTBZQhyByZmz5oUgRKUQJO5V5AOiJxsVEGbUmgA7sJRQeTrXLB+BEwzaKS5nm2opJeNyMBYLFNK4hiQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@scalar/hono-api-reference": {
-			"version": "0.11.8",
-			"resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.11.8.tgz",
-			"integrity": "sha512-LsRSlm6Uh6p28LvWalJ++38ObMmXJmY+XhdZiNgeED3nNprgp/DsX/z9wj0Xps5kaIAphGOT3lL4LUGF/9XmwA==",
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/@scalar/hono-api-reference/-/hono-api-reference-0.11.11.tgz",
+			"integrity": "sha512-yvJ2oqyG9MC4C55/Xvi/Jny5qBYDxDvoVleABhgNG24A93u9ar17qsdSppli94sQOUdX31Qw/yCTm89LHbBRiQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/client-side-rendering": "0.3.1"
+				"@scalar/client-side-rendering": "0.3.4"
 			},
 			"engines": {
 				"node": ">=22"
@@ -5275,25 +5174,25 @@
 			}
 		},
 		"node_modules/@scalar/schemas": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.7.1.tgz",
-			"integrity": "sha512-80bxEp4ZOWxOm8kqhPi3kdJ2gipz2lZBSEHStAh3Z6NZPkFAOlZZYnDFwodhY0LwTihgvv4FVNmi64gziM0F1g==",
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.7.4.tgz",
+			"integrity": "sha512-Or31zxR+ceGGhkVU5XBO2Zv7oyGDtjsJOjM2Rr0WRZ1/tRsQc2/FsVv+9kPmCA7sqFL8BKWlNfTXcPITI7WRHw==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/helpers": "0.9.0",
-				"@scalar/validation": "0.6.0"
+				"@scalar/helpers": "0.9.2",
+				"@scalar/validation": "0.6.2"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@scalar/types": {
-			"version": "0.16.1",
-			"resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.16.1.tgz",
-			"integrity": "sha512-zzApf0dtEqztdY//3gmRJTgySGMpKnAVqcZltAzt95yuQPXbkSqxXDTitBLd1abeSeik+W6GFTIjffL8K+1wqQ==",
+			"version": "0.16.4",
+			"resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.16.4.tgz",
+			"integrity": "sha512-fLf0ANAC3iQq0sIVdmH6aGM+pFSLyD8GfGBxSWcLpI0jE0iFAzX2A3p0qVZm7vqBT4TQnn0fSwg5U+h+FZ52BA==",
 			"license": "MIT",
 			"dependencies": {
-				"@scalar/helpers": "0.9.0",
+				"@scalar/helpers": "0.9.2",
 				"nanoid": "^5.1.6",
 				"type-fest": "^5.3.1",
 				"zod": "^4.3.5"
@@ -5321,18 +5220,18 @@
 			}
 		},
 		"node_modules/@scalar/validation": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.0.tgz",
-			"integrity": "sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.2.tgz",
+			"integrity": "sha512-Sc1TkcwGV6aVCO51AyKeaGiP8gpwAHxEtO5d3tZzPV+KsnlC/YokQxFxwBrbIXw73k9hmcExnJyGu3k5i6n6VA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			}
 		},
 		"node_modules/@sebastianwessel/isostate": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@sebastianwessel/isostate/-/isostate-0.4.0.tgz",
-			"integrity": "sha512-BoV/ZNXZLMSbNv+r9Cizmrh3lMsIk9/I/bYVxFGMI1jK1epolYUJDZ9Qg8wMqROabzfSEoIM6saILTkFMYPZOw==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@sebastianwessel/isostate/-/isostate-0.5.0.tgz",
+			"integrity": "sha512-iRlxI41eEAZDFhj91Szb6UZTCqZtyrRjDqmdFywlZhs6Iy4Z56p/ty3W12jT5362l4EfOviP/TTSZdWYgRK27g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.0.0"
@@ -5347,13 +5246,13 @@
 			}
 		},
 		"node_modules/@sebastianwessel/isostate-cli": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@sebastianwessel/isostate-cli/-/isostate-cli-0.4.0.tgz",
-			"integrity": "sha512-W3175OpBCR8JzcdwZKrXOJfxwOrXFsEPYZ+t+zGdCZqSm4facKla3ZNno8N+9tH44e/R/WUs4cNLgB0i909rmQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@sebastianwessel/isostate-cli/-/isostate-cli-0.5.0.tgz",
+			"integrity": "sha512-ngwlje5ivq+PsYFsx1H+CqkofgoZPoEpzz87HPJAhlyJ1sUB/kpsgtdYlYbLIke227If6j4AMVMK3unUANaLZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sebastianwessel/isostate": "0.4.0"
+				"@sebastianwessel/isostate": "0.5.0"
 			},
 			"bin": {
 				"isostate": "dist/bin.js"
@@ -5587,12 +5486,12 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.29.1",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
-			"integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+			"version": "3.29.5",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+			"integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.15.1",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5600,13 +5499,13 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
-			"integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+			"integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.1",
-				"@smithy/types": "^4.15.1",
+				"@smithy/core": "^3.29.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5614,13 +5513,13 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
-			"integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+			"version": "5.6.7",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+			"integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.1",
-				"@smithy/types": "^4.15.1",
+				"@smithy/core": "^3.29.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5628,13 +5527,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
-			"integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+			"version": "4.9.7",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+			"integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.1",
-				"@smithy/types": "^4.15.1",
+				"@smithy/core": "^3.29.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5642,13 +5541,13 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
-			"integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+			"version": "5.6.6",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+			"integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.29.1",
-				"@smithy/types": "^4.15.1",
+				"@smithy/core": "^3.29.5",
+				"@smithy/types": "^4.16.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -5656,9 +5555,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
-			"integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -5945,47 +5844,47 @@
 			}
 		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-			"integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+			"integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
-				"enhanced-resolve": "5.21.6",
+				"enhanced-resolve": "^5.24.1",
 				"jiti": "^2.7.0",
 				"lightningcss": "1.32.0",
 				"magic-string": "^0.30.21",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.3.2"
+				"tailwindcss": "4.3.3"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-			"integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+			"integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.3.2",
-				"@tailwindcss/oxide-darwin-arm64": "4.3.2",
-				"@tailwindcss/oxide-darwin-x64": "4.3.2",
-				"@tailwindcss/oxide-freebsd-x64": "4.3.2",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-				"@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-				"@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+				"@tailwindcss/oxide-android-arm64": "4.3.3",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.3",
+				"@tailwindcss/oxide-darwin-x64": "4.3.3",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.3",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-			"integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+			"integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
 			"cpu": [
 				"arm64"
 			],
@@ -5999,9 +5898,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-			"integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+			"integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
 			"cpu": [
 				"arm64"
 			],
@@ -6015,9 +5914,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-			"integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+			"integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
 			"cpu": [
 				"x64"
 			],
@@ -6031,9 +5930,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-			"integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+			"integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
 			"cpu": [
 				"x64"
 			],
@@ -6047,9 +5946,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-			"integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+			"integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
 			"cpu": [
 				"arm"
 			],
@@ -6063,9 +5962,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-			"integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+			"integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -6082,9 +5981,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-			"integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+			"integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
 			"cpu": [
 				"arm64"
 			],
@@ -6101,9 +6000,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-			"integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+			"integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
 			"cpu": [
 				"x64"
 			],
@@ -6120,9 +6019,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-			"integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+			"integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
 			"cpu": [
 				"x64"
 			],
@@ -6139,9 +6038,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-			"integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+			"integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -6168,9 +6067,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-			"integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+			"integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -6184,9 +6083,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-			"integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+			"integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
 			"cpu": [
 				"x64"
 			],
@@ -6200,79 +6099,41 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
-			"integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+			"integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.3.2",
-				"@tailwindcss/oxide": "4.3.2",
-				"tailwindcss": "4.3.2"
+				"@tailwindcss/node": "4.3.3",
+				"@tailwindcss/oxide": "4.3.3",
+				"tailwindcss": "4.3.3"
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
 		"node_modules/@temporalio/activity": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.20.0.tgz",
-			"integrity": "sha512-XiSZHH2lc5i5psy/yhO6n0lrz2KMH7RitJzzq59F3etjtdWOeMkaL0HgngwDyjMAcqnT1eyKe0BN4wkuDhmsQA==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.20.3.tgz",
+			"integrity": "sha512-7jtIkCkUe6wwVrnlCd/7DmnVcu1/r4KFvVHvPVszd/EXAz1ziYfsjhenLfxWIvyxSIU9v3tC96uHODN3ABdv4A==",
 			"license": "MIT",
 			"dependencies": {
-				"@temporalio/client": "1.20.0",
-				"@temporalio/common": "1.20.0"
+				"@temporalio/client": "1.20.3",
+				"@temporalio/common": "1.20.3"
 			},
 			"engines": {
 				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.20.0",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "^7.6.4"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/activity/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
 			}
 		},
 		"node_modules/@temporalio/client": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.20.0.tgz",
-			"integrity": "sha512-1uSc2JyfALm6bdIJxMA/5ThzkNCKZrktqCOx4H22kjelb9qZsuD49Ki+3NUQKkDDfsj20xio6GrDal8jHChy/w==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.20.3.tgz",
+			"integrity": "sha512-RmEX0Z7h3mWq8PMqeDSbbDZPK8IweajGnRsghiJI0fnaWx61YeW8bhAAKfD/iSop+0PM0oe0KaW5XPAKEY4XEw==",
 			"license": "MIT",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.12.4",
-				"@temporalio/common": "1.20.0",
-				"@temporalio/proto": "1.20.0",
+				"@temporalio/common": "1.20.3",
+				"@temporalio/proto": "1.20.3",
 				"abort-controller": "^3.0.0",
 				"long": "^5.2.3",
 				"nexus-rpc": "^0.0.2",
@@ -6282,13 +6143,13 @@
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/client/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
+		"node_modules/@temporalio/common": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.3.tgz",
+			"integrity": "sha512-VM9GyUAa7tl413nM24mcBhUfUeqcGazmDkx/GfDA0c+KuEVusclMg9eqa63EDv/rguC/YhWaXu6q5Kl8+99GSw==",
 			"license": "MIT",
 			"dependencies": {
-				"@temporalio/proto": "1.20.0",
+				"@temporalio/proto": "1.20.3",
 				"long": "^5.2.3",
 				"ms": "3.0.0-canary.1",
 				"nexus-rpc": "^0.0.2",
@@ -6298,20 +6159,7 @@
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/client/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "^7.6.4"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/client/node_modules/ms": {
+		"node_modules/@temporalio/common/node_modules/ms": {
 			"version": "3.0.0-canary.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
 			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
@@ -6321,65 +6169,92 @@
 			}
 		},
 		"node_modules/@temporalio/core-bridge": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.20.0.tgz",
-			"integrity": "sha512-ueYAkdiT0mQ18zIPqDUtszejJOhiJT6nPq1Rxs4GHbTIc64WOMBvnKDGC//QNOov6Ci23yA7nioR1eRjRI9/3Q==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.20.3.tgz",
+			"integrity": "sha512-i7hu6lg6bm2esyYYDwHh0XmGkOWSL5iicLjC7DNRU4b4As/dKcRxYMxNY6dXtKzbM94xhmX6Fh4j5/fxen/4kw==",
 			"license": "MIT",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.12.4",
-				"@temporalio/common": "1.20.0"
+				"@temporalio/common": "1.20.3"
 			},
 			"engines": {
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
+		"node_modules/@temporalio/interceptors-opentelemetry": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/interceptors-opentelemetry/-/interceptors-opentelemetry-1.20.3.tgz",
+			"integrity": "sha512-QOL4E/NEmv9NU8S/vSp+G0TaeSMY+RqZFb8SpnIUueZj3H/BeU3Pc4d14R03LLIW1LRAxP6fhKIlOOF+wYVfQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@temporalio/proto": "1.20.0",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/core": "^1.25.1",
+				"@opentelemetry/resources": "^1.25.1",
+				"@opentelemetry/sdk-trace-base": "^1.25.1",
+				"@temporalio/plugin": "1.20.3"
 			},
 			"engines": {
 				"node": ">= 20.3.0"
+			},
+			"peerDependencies": {
+				"@temporalio/common": "1.20.3",
+				"@temporalio/workflow": "1.20.3"
+			},
+			"peerDependenciesMeta": {
+				"@temporalio/workflow": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
-			"license": "MIT",
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "^7.6.4"
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
-				"node": ">= 20.3.0"
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
-		"node_modules/@temporalio/core-bridge/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/resources": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
 			"engines": {
-				"node": ">=12.13"
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@temporalio/interceptors-opentelemetry/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@temporalio/nexus": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.20.0.tgz",
-			"integrity": "sha512-gAWHIbZ76zbIjAjkuYbGjxdpelDU5RnNOO+osipvRlx1c8jTYDBm+YCFDmXgI3dbCBysUKTPm6NxGeOM/fJs0A==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.20.3.tgz",
+			"integrity": "sha512-OSl73enJ9M8OMk2QaGHr4cQ1DDLEkjMhU1Z3tBt2zbWkKDs2IHKkl1wU/rMeXg7AJf5uqHcp209SBaDN/rqDiA==",
 			"license": "MIT",
 			"dependencies": {
-				"@temporalio/client": "1.20.0",
-				"@temporalio/common": "1.20.0",
-				"@temporalio/proto": "1.20.0",
+				"@temporalio/client": "1.20.3",
+				"@temporalio/common": "1.20.3",
+				"@temporalio/proto": "1.20.3",
 				"long": "^5.2.3",
 				"nexus-rpc": "^0.0.2"
 			},
@@ -6387,26 +6262,19 @@
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
+		"node_modules/@temporalio/plugin": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.20.3.tgz",
+			"integrity": "sha512-gWs3ulAf15u+M/CG8WMC9cepf8KxOKTJkTSXCEja6eT3McUyDEL1heZ/XYLc/hTRL/Yj7or8y2Jydn3EG60TNA==",
 			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.20.0",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
 			"engines": {
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
+		"node_modules/@temporalio/proto": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.3.tgz",
+			"integrity": "sha512-RdbHC3zH+N0QqG1Q38h2LilFIQ3lbGLVmLYCyNcV+PPfzrtrZ8pwBACpSGwEuF7WWFziLAhJ2oMVXTnmXY5ocQ==",
 			"license": "MIT",
 			"dependencies": {
 				"long": "^5.2.3",
@@ -6416,30 +6284,21 @@
 				"node": ">= 20.3.0"
 			}
 		},
-		"node_modules/@temporalio/nexus/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
-			}
-		},
 		"node_modules/@temporalio/worker": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.20.0.tgz",
-			"integrity": "sha512-kNYOwFZFMJTQeWvv9K8KV4Ci7wJ3D1z8dzD7uDcXrs1by1xPt8JJDGAYxS0y+KjPqK6gPa1rL15sX3CCvU3lcw==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.20.3.tgz",
+			"integrity": "sha512-29W39KxGoz8QfiELT5al1jr+nnZEnpWCjr5gYT2a6ZlXr2WKxbJw4rRBy+OyGwHs5kGT0pPYayYvwcDTvWRpQQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.12.4",
 				"@swc/core": "^1.3.102",
-				"@temporalio/activity": "1.20.0",
-				"@temporalio/client": "1.20.0",
-				"@temporalio/common": "1.20.0",
-				"@temporalio/core-bridge": "1.20.0",
-				"@temporalio/nexus": "1.20.0",
-				"@temporalio/proto": "1.20.0",
-				"@temporalio/workflow": "1.20.0",
+				"@temporalio/activity": "1.20.3",
+				"@temporalio/client": "1.20.3",
+				"@temporalio/common": "1.20.3",
+				"@temporalio/core-bridge": "1.20.3",
+				"@temporalio/nexus": "1.20.3",
+				"@temporalio/proto": "1.20.3",
+				"@temporalio/workflow": "1.20.3",
 				"heap-js": "^2.6.0",
 				"memfs": "^4.6.0",
 				"nexus-rpc": "^0.0.2",
@@ -6450,62 +6309,10 @@
 				"supports-color": "^8.1.1",
 				"swc-loader": "^0.2.3",
 				"unionfs": "^4.5.1",
-				"webpack": "^5.106.2"
+				"webpack": "^5.108.4"
 			},
 			"engines": {
 				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/common": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.20.0.tgz",
-			"integrity": "sha512-ixzLkXk0VfdyyADFA+T8z+JlxmuL7e9Of3uh525P/JjhHl01FR4sornpTjnjl0+4WLH6FfcPu/X2T+KPpna7EQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/proto": "1.20.0",
-				"long": "^5.2.3",
-				"ms": "3.0.0-canary.1",
-				"nexus-rpc": "^0.0.2",
-				"proto3-json-serializer": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/proto": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.20.0.tgz",
-			"integrity": "sha512-mgLkUhT5XNAbNPpvkw0C6qLtcsiS2Av4GoJnLxtsjEUVJg3Fegai8dmZ+LAYF/YdPmVrTonJmRMolmlGj2rpyA==",
-			"license": "MIT",
-			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "^7.6.4"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/@temporalio/workflow": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.20.0.tgz",
-			"integrity": "sha512-L10zSOW+6WCiI+0a679P58ib9nXAuNeME/Pr23djWzrXy1zQh9apUlyp4UCaLzdcaaXURqWMWUhNc31/RvRThw==",
-			"license": "MIT",
-			"dependencies": {
-				"@temporalio/common": "1.20.0",
-				"@temporalio/proto": "1.20.0",
-				"nexus-rpc": "^0.0.2"
-			},
-			"engines": {
-				"node": ">= 20.3.0"
-			}
-		},
-		"node_modules/@temporalio/worker/node_modules/ms": {
-			"version": "3.0.0-canary.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-			"integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.13"
 			}
 		},
 		"node_modules/@temporalio/worker/node_modules/supports-color": {
@@ -6521,6 +6328,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/@temporalio/workflow": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.20.3.tgz",
+			"integrity": "sha512-6LRfnWp3HcvqvKFwbOhs5iDQkHNIM5Rxtxhsi2E5ViPDvJMBqlQ0sQ4oRo5SEgr5Bri650i7GfEQQJMVl7xoKg==",
+			"license": "MIT",
+			"dependencies": {
+				"@temporalio/common": "1.20.3",
+				"@temporalio/proto": "1.20.3",
+				"nexus-rpc": "^0.0.2"
+			},
+			"engines": {
+				"node": ">= 20.3.0"
 			}
 		},
 		"node_modules/@testcontainers/nats": {
@@ -6942,26 +6763,6 @@
 				"@types/ssh2": "*"
 			}
 		},
-		"node_modules/@types/eslint": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*",
-				"@types/json-schema": "*"
-			}
-		},
-		"node_modules/@types/eslint-scope": {
-			"version": "3.7.7",
-			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/eslint": "*",
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -7074,9 +6875,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "26.1.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~8.3.0"
@@ -7147,23 +6948,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/ssh2/node_modules/@types/node": {
-			"version": "18.19.130",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-			"integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~5.26.4"
-			}
-		},
-		"node_modules/@types/ssh2/node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -7178,9 +6962,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/three": {
-			"version": "0.185.0",
-			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
-			"integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+			"version": "0.185.1",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+			"integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
 			"license": "MIT",
 			"dependencies": {
 				"@dimforge/rapier3d-compat": "~0.12.0",
@@ -8411,15 +8195,15 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-7.0.6.tgz",
-			"integrity": "sha512-Myw0sFia+zs/Y0yqfZEsUYXfDPh3ELcLf1f0Q/qQzVXBh/af1qO62WNT+P89DCcfGVV51nMoQhEfkBYqJmoUOQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-7.1.1.tgz",
+			"integrity": "sha512-yfKhuvbz+DORHihJRL1DHcxyLcX9uTrxvz2nCSTzHH54k2DdACBfuOu2OAAAhdUC9xlu2IRXAiagqcPL3DftCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/compiler-rs": "^0.3.0",
+				"@astrojs/compiler-rs": "^0.3.1",
 				"@astrojs/internal-helpers": "0.10.1",
-				"@astrojs/markdown-satteri": "0.3.3",
-				"@astrojs/telemetry": "3.3.2",
+				"@astrojs/markdown-satteri": "0.3.4",
+				"@astrojs/telemetry": "3.3.3",
 				"@capsizecss/unpack": "^4.0.0",
 				"@clack/prompts": "^1.1.0",
 				"@oslojs/encoding": "^1.1.0",
@@ -10609,9 +10393,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.21.6",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+			"version": "5.24.3",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+			"integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -11604,12 +11388,6 @@
 				"tslib": "2"
 			}
 		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/globby": {
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
@@ -12140,9 +11918,9 @@
 			"license": "MIT"
 		},
 		"node_modules/hono": {
-			"version": "4.12.28",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-			"integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+			"version": "4.12.31",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+			"integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -14790,6 +14568,66 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/minimizer-webpack-plugin": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+			"integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^4.3.0",
+				"terser": "^5.31.1"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@minify-html/node": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/css": {
+					"optional": true
+				},
+				"@swc/html": {
+					"optional": true
+				},
+				"clean-css": {
+					"optional": true
+				},
+				"cssnano": {
+					"optional": true
+				},
+				"csso": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"html-minifier-terser": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/minipass": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -17283,9 +17121,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-			"integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+			"integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
 			"license": "MIT"
 		},
 		"node_modules/tapable": {
@@ -17370,66 +17208,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/terser-webpack-plugin": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-			"integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.25",
-				"jest-worker": "^27.4.5",
-				"schema-utils": "^4.3.0",
-				"terser": "^5.31.1"
-			},
-			"engines": {
-				"node": ">= 10.13.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/webpack"
-			},
-			"peerDependencies": {
-				"webpack": "^5.1.0"
-			},
-			"peerDependenciesMeta": {
-				"@minify-html/node": {
-					"optional": true
-				},
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/css": {
-					"optional": true
-				},
-				"@swc/html": {
-					"optional": true
-				},
-				"clean-css": {
-					"optional": true
-				},
-				"cssnano": {
-					"optional": true
-				},
-				"csso": {
-					"optional": true
-				},
-				"esbuild": {
-					"optional": true
-				},
-				"html-minifier-terser": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"uglify-js": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/terser/node_modules/commander": {
@@ -17760,9 +17538,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+			"integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18521,12 +18299,11 @@
 			"license": "MIT"
 		},
 		"node_modules/watchpack": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+			"integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
 			"license": "MIT",
 			"dependencies": {
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
 			},
 			"engines": {
@@ -18553,12 +18330,11 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.106.2",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-			"integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+			"version": "5.108.4",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+			"integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
 				"@webassemblyjs/ast": "^1.14.1",
@@ -18568,20 +18344,19 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.20.0",
-				"es-module-lexer": "^2.0.0",
+				"enhanced-resolve": "^5.22.2",
+				"es-module-lexer": "^2.1.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
-				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"loader-runner": "^4.3.1",
+				"loader-runner": "^4.3.2",
 				"mime-db": "^1.54.0",
+				"minimizer-webpack-plugin": "^5.6.1",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.17",
-				"watchpack": "^2.5.1",
-				"webpack-sources": "^3.3.4"
+				"watchpack": "^2.5.2",
+				"webpack-sources": "^3.5.0"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -18600,9 +18375,9 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.1.tgz",
-			"integrity": "sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+			"integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
@@ -18630,15 +18405,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-pm-runs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-			"integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/why-is-node-running": {
@@ -18977,13 +18743,13 @@
 				"@opentelemetry/instrumentation-amqplib": "^0.67.0",
 				"@opentelemetry/resources": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
 				"amqplib": "^2.0.1"
 			},
 			"devDependencies": {
 				"@types/amqplib": "^0.10.8",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -18997,11 +18763,11 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-ssm": "^3.1081.0",
+				"@aws-sdk/client-ssm": "^3.1090.0",
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.4",
@@ -19016,11 +18782,11 @@
 			"version": "3.2.2",
 			"license": "ISC",
 			"dependencies": {
-				"@aws-sdk/client-secrets-manager": "^3.1081.0",
+				"@aws-sdk/client-secrets-manager": "^3.1090.0",
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.4",
@@ -19040,7 +18806,7 @@
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"dotenv": "^17.4.2",
 				"sinon": "^22.0.0",
@@ -19057,12 +18823,12 @@
 			"license": "ISC",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
-				"hono": "^4.12.28"
+				"hono": "^4.12.31"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19090,10 +18856,10 @@
 			},
 			"devDependencies": {
 				"@types/minimist": "^1.2.5",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"rimraf": "^6.1.3",
-				"tsx": "^4.23.0",
+				"tsx": "^4.23.1",
 				"type-fest": "^5.8.0"
 			},
 			"engines": {
@@ -19133,7 +18899,7 @@
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/resources": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/harness": "^1.7.0",
 				"@sodaru/yup-to-json-schema": "^2.0.1",
 				"@standard-schema/spec": "^1.1.0",
@@ -19145,7 +18911,7 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"rimraf": "^6.1.3",
 				"vitest": "^4.1.10",
@@ -19161,15 +18927,15 @@
 			"license": "ISC",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/base-http-bridge": "*",
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@hono/node-server": "^2.0.8",
-				"@types/node": "^26.1.0",
+				"@hono/node-server": "^2.0.10",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
-				"hono": "^4.12.28",
+				"hono": "^4.12.31",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
 			},
@@ -19186,7 +18952,7 @@
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19201,13 +18967,13 @@
 			"license": "ISC",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
-				"hono": "^4.12.28"
+				"hono": "^4.12.31"
 			},
 			"devDependencies": {
 				"@hono/swagger-ui": "^0.6.1",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19216,7 +18982,7 @@
 				"node": ">=24.15.0"
 			},
 			"optionalDependencies": {
-				"@hono/node-server": "^2.0.8"
+				"@hono/node-server": "^2.0.10"
 			}
 		},
 		"packages/infisical-secret-store": {
@@ -19227,7 +18993,7 @@
 				"@purista/core": "*"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19242,13 +19008,13 @@
 			"license": "ISC",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
-				"hono": "^4.12.28"
+				"hono": "^4.12.31"
 			},
 			"devDependencies": {
-				"@hono/node-server": "^2.0.8",
-				"@types/node": "^26.1.0",
+				"@hono/node-server": "^2.0.10",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19265,12 +19031,12 @@
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/resources": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
 				"mqtt": "^5.15.2"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@types/ws": "^8.18.1",
 				"sinon": "^22.0.0",
@@ -19290,7 +19056,7 @@
 			},
 			"devDependencies": {
 				"@testcontainers/nats": "^12.0.4",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19309,7 +19075,7 @@
 			},
 			"devDependencies": {
 				"@testcontainers/nats": "^12.0.4",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"vitest": "^4.1.10"
 			},
 			"engines": {
@@ -19326,7 +19092,7 @@
 			},
 			"devDependencies": {
 				"@testcontainers/nats": "^12.0.4",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19343,13 +19109,13 @@
 				"@opentelemetry/api": "^1.9.1",
 				"@opentelemetry/resources": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
-				"@opentelemetry/semantic-conventions": "^1.42.0",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"@purista/core": "*",
 				"nats": "^2.29.3"
 			},
 			"devDependencies": {
 				"@testcontainers/nats": "^12.0.4",
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"@types/ws": "^8.18.1",
 				"sinon": "^22.0.0",
@@ -19368,7 +19134,7 @@
 				"@redis/client": "^6.1.0"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19386,7 +19152,7 @@
 				"@redis/client": "^6.1.0"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19404,7 +19170,7 @@
 				"@redis/client": "^6.1.0"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"vitest": "^4.1.10"
@@ -19422,7 +19188,7 @@
 				"node-vault": "^0.12.0"
 			},
 			"devDependencies": {
-				"@types/node": "^26.1.0",
+				"@types/node": "^26.1.1",
 				"@types/sinon": "^22.0.0",
 				"sinon": "^22.0.0",
 				"testcontainers": "^12.0.4",
@@ -19436,17 +19202,17 @@
 			"name": "@purista/web",
 			"version": "3.2.2",
 			"dependencies": {
-				"@astrojs/mdx": "^7.0.2",
+				"@astrojs/mdx": "^7.0.3",
 				"@astrojs/react": "^6.0.1",
-				"@fontsource/inter": "^5.2.8",
-				"@sebastianwessel/isostate": "^0.4.0",
+				"@fontsource/inter": "^5.3.0",
+				"@sebastianwessel/isostate": "^0.5.0",
 				"@shikijs/transformers": "^4.3.1",
-				"@tailwindcss/vite": "^4.3.2",
+				"@tailwindcss/vite": "^4.3.3",
 				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.2.3",
-				"@types/three": "^0.185.0",
+				"@types/three": "^0.185.1",
 				"@xyflow/react": "^12.11.2",
-				"astro": "^7.0.6",
+				"astro": "^7.1.1",
 				"astro-og-canvas": "^0.13.0",
 				"beautiful-mermaid": "^1.1.3",
 				"gsap": "^3.15.0",
@@ -19455,49 +19221,15 @@
 				"react": "^19.2.7",
 				"react-dom": "^19.2.7",
 				"shiki": "^4.3.1",
-				"tailwindcss": "^4.3.2",
+				"tailwindcss": "^4.3.3",
 				"three": "^0.185.1"
 			},
 			"devDependencies": {
-				"@sebastianwessel/isostate-cli": "^0.4.0",
-				"vite": "^8.1.3"
+				"@sebastianwessel/isostate-cli": "^0.5.0",
+				"vite": "^8.1.5"
 			},
 			"engines": {
 				"node": ">=22.0.0"
-			}
-		},
-		"web/node_modules/@astrojs/mdx": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.2.tgz",
-			"integrity": "sha512-l+sJY5U1KkGZUdr+bIL4Y6BefeS549qoSHVSkUSs6A9INwdCND+/0+vN0NroPBXwl5Vcg5u78t7VQRsJjePxbw==",
-			"license": "MIT",
-			"dependencies": {
-				"@astrojs/internal-helpers": "0.10.1",
-				"@astrojs/markdown-remark": "7.2.1",
-				"@mdx-js/mdx": "^3.1.1",
-				"acorn": "^8.16.0",
-				"es-module-lexer": "^2.0.0",
-				"estree-util-visit": "^2.0.0",
-				"hast-util-to-html": "^9.0.5",
-				"piccolore": "^0.1.3",
-				"rehype-raw": "^7.0.0",
-				"remark-gfm": "^4.0.1",
-				"remark-smartypants": "^3.0.2",
-				"source-map": "^0.7.6",
-				"unist-util-visit": "^5.1.0",
-				"vfile": "^6.0.3"
-			},
-			"engines": {
-				"node": ">=22.12.0"
-			},
-			"peerDependencies": {
-				"@astrojs/markdown-satteri": "^0.3.1",
-				"astro": "^7.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@astrojs/markdown-satteri": {
-					"optional": true
-				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
 		"web"
 	],
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.2",
-		"@types/node": "^26.1.0",
+		"@biomejs/biome": "^2.5.4",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@typescript/native": "npm:typescript@^7.0.2",
 		"@vitest/coverage-v8": "^4.1.10",
@@ -56,7 +56,7 @@
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.4",
 		"ts-node": "^10.9.2",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"typedoc": "^0.28.20",
 		"typescript": "npm:@typescript/typescript6@^6.0.2",
 		"vitest": "^4.1.10"

--- a/packages/amqpbridge/package.json
+++ b/packages/amqpbridge/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@types/amqplib": "^0.10.8",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"
@@ -43,7 +43,7 @@
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/resources": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@opentelemetry/instrumentation-amqplib": "^0.67.0",
 		"@purista/core": "*",
 		"amqplib": "^2.0.1"

--- a/packages/aws-config-store/package.json
+++ b/packages/aws-config-store/package.json
@@ -35,14 +35,14 @@
 		"env:down": "docker compose -f docker-compose.yml down"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.4",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@aws-sdk/client-ssm": "^3.1081.0",
+		"@aws-sdk/client-ssm": "^3.1090.0",
 		"@purista/core": "*"
 	},
 	"peerDependenciesMeta": {},

--- a/packages/aws-secret-store/package.json
+++ b/packages/aws-secret-store/package.json
@@ -35,14 +35,14 @@
 		"env:down": "docker compose -f docker-compose.yml down"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.4",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
-		"@aws-sdk/client-secrets-manager": "^3.1081.0",
+		"@aws-sdk/client-secrets-manager": "^3.1090.0",
 		"@purista/core": "*"
 	},
 	"peerDependenciesMeta": {},

--- a/packages/azure-secret-store/package.json
+++ b/packages/azure-secret-store/package.json
@@ -35,7 +35,7 @@
 		"env:down": "docker compose -f docker-compose.yml down"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"dotenv": "^17.4.2",
 		"sinon": "^22.0.0",

--- a/packages/base-http-bridge/package.json
+++ b/packages/base-http-bridge/package.json
@@ -25,16 +25,16 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
-		"hono": "^4.12.28"
+		"hono": "^4.12.31"
 	},
 	"peerDependenciesMeta": {},
 	"exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,10 +29,10 @@
 	},
 	"devDependencies": {
 		"@types/minimist": "^1.2.5",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"rimraf": "^6.1.3",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
 		"type-fest": "^5.8.0"
 	},
 	"dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
 		"test:integration": "vitest -c ../../vitest.config.ts"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"rimraf": "^6.1.3",
 		"vitest": "^4.1.10",
@@ -37,7 +37,7 @@
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/resources": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/harness": "^1.7.0",
 		"@sodaru/yup-to-json-schema": "^2.0.1",
 		"@standard-schema/spec": "^1.1.0",

--- a/packages/dapr-sdk/package.json
+++ b/packages/dapr-sdk/package.json
@@ -38,16 +38,16 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@hono/node-server": "^2.0.8",
-		"@types/node": "^26.1.0",
+		"@hono/node-server": "^2.0.10",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
-		"hono": "^4.12.28",
+		"hono": "^4.12.31",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/base-http-bridge": "*",
 		"@purista/core": "*"
 	},

--- a/packages/gcloud-secret-store/package.json
+++ b/packages/gcloud-secret-store/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/hono-http-server/package.json
+++ b/packages/hono-http-server/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@hono/swagger-ui": "^0.6.1",
 		"sinon": "^22.0.0",
@@ -41,13 +41,13 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
-		"hono": "^4.12.28"
+		"hono": "^4.12.31"
 	},
 	"peerDependenciesMeta": {},
 	"optionalDependencies": {
-		"@hono/node-server": "^2.0.8"
+		"@hono/node-server": "^2.0.10"
 	},
 	"types": "./dist/index.d.ts"
 }

--- a/packages/infisical-secret-store/package.json
+++ b/packages/infisical-secret-store/package.json
@@ -35,7 +35,7 @@
 		"env:down": "docker compose -f docker-compose.yml down"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/k8s-sdk/package.json
+++ b/packages/k8s-sdk/package.json
@@ -33,17 +33,17 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@hono/node-server": "^2.0.8",
-		"@types/node": "^26.1.0",
+		"@hono/node-server": "^2.0.10",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
-		"hono": "^4.12.28"
+		"hono": "^4.12.31"
 	},
 	"types": "./dist/index.d.ts"
 }

--- a/packages/mqttbridge/package.json
+++ b/packages/mqttbridge/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@types/ws": "^8.18.1",
 		"sinon": "^22.0.0",
@@ -43,7 +43,7 @@
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/resources": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
 		"mqtt": "^5.15.2"
 	},

--- a/packages/nats-config-store/package.json
+++ b/packages/nats-config-store/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@testcontainers/nats": "^12.0.4",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/nats-queue-bridge/package.json
+++ b/packages/nats-queue-bridge/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@testcontainers/nats": "^12.0.4",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"vitest": "^4.1.10"
 	},
 	"dependencies": {

--- a/packages/nats-state-store/package.json
+++ b/packages/nats-state-store/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@testcontainers/nats": "^12.0.4",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/natsbridge/package.json
+++ b/packages/natsbridge/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@testcontainers/nats": "^12.0.4",
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"@types/ws": "^8.18.1",
 		"sinon": "^22.0.0",
@@ -44,7 +44,7 @@
 		"@opentelemetry/api": "^1.9.1",
 		"@opentelemetry/resources": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
-		"@opentelemetry/semantic-conventions": "^1.42.0",
+		"@opentelemetry/semantic-conventions": "^1.43.0",
 		"@purista/core": "*",
 		"nats": "^2.29.3"
 	},

--- a/packages/redis-config-store/package.json
+++ b/packages/redis-config-store/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/redis-queue-bridge/package.json
+++ b/packages/redis-queue-bridge/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/redis-state-store/package.json
+++ b/packages/redis-state-store/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"vitest": "^4.1.10"

--- a/packages/vault-secret-store/package.json
+++ b/packages/vault-secret-store/package.json
@@ -33,7 +33,7 @@
 		"build": "rimraf dist tsconfig.tsbuildinfo && tsc -p tsconfig.build.json"
 	},
 	"devDependencies": {
-		"@types/node": "^26.1.0",
+		"@types/node": "^26.1.1",
 		"@types/sinon": "^22.0.0",
 		"sinon": "^22.0.0",
 		"testcontainers": "^12.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -14,17 +14,17 @@
 		"astro": "astro"
 	},
 	"dependencies": {
-		"@astrojs/mdx": "^7.0.2",
+		"@astrojs/mdx": "^7.0.3",
 		"@astrojs/react": "^6.0.1",
-		"@fontsource/inter": "^5.2.8",
-		"@sebastianwessel/isostate": "^0.4.0",
+		"@fontsource/inter": "^5.3.0",
+		"@sebastianwessel/isostate": "^0.5.0",
 		"@shikijs/transformers": "^4.3.1",
-		"@tailwindcss/vite": "^4.3.2",
+		"@tailwindcss/vite": "^4.3.3",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
-		"@types/three": "^0.185.0",
+		"@types/three": "^0.185.1",
 		"@xyflow/react": "^12.11.2",
-		"astro": "^7.0.6",
+		"astro": "^7.1.1",
 		"astro-og-canvas": "^0.13.0",
 		"beautiful-mermaid": "^1.1.3",
 		"gsap": "^3.15.0",
@@ -33,11 +33,11 @@
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
 		"shiki": "^4.3.1",
-		"tailwindcss": "^4.3.2",
+		"tailwindcss": "^4.3.3",
 		"three": "^0.185.1"
 	},
 	"devDependencies": {
-		"@sebastianwessel/isostate-cli": "^0.4.0",
-		"vite": "^8.1.3"
+		"@sebastianwessel/isostate-cli": "^0.5.0",
+		"vite": "^8.1.5"
 	}
 }


### PR DESCRIPTION
## Summary

- Update all direct workspace dependencies to their latest releases.
- Regenerate the npm lockfile from the refreshed dependency graph.
- Preserve the TypeScript 7 native compiler and the TypeScript 6 compatibility alias.

## Validation

- Dependency-version consistency check
- Unit tests: 639 passing
- Full build
- Package-import smoke test

## Notes

npm audit --omit=dev still reports four moderate findings inherited through Temporal's current OpenTelemetry 1.x dependency chain. Temporal 1.20.3 is the latest release and has no compatible upstream update for that chain.