### PR TITLE
chore: update AI Harness to 1.7.1

### DIFF
--- a/examples/agent-example/package.json
+++ b/examples/agent-example/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@hono/node-server": "^2.0.10",
 		"@purista/core": "*",
-		"@purista/harness-openai": "^1.7.0",
+		"@purista/harness-openai": "^1.7.1",
 		"@purista/hono-http-server": "*",
 		"@scalar/hono-api-reference": "^0.11.11",
 		"dotenv": "^17.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 			"dependencies": {
 				"@hono/node-server": "^2.0.10",
 				"@purista/core": "*",
-				"@purista/harness-openai": "^1.7.0",
+				"@purista/harness-openai": "^1.7.1",
 				"@purista/hono-http-server": "*",
 				"@scalar/hono-api-reference": "^0.11.11",
 				"dotenv": "^17.4.2",
@@ -4684,12 +4684,12 @@
 			"link": true
 		},
 		"node_modules/@purista/harness": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@purista/harness/-/harness-1.7.0.tgz",
-			"integrity": "sha512-6A+ZhOh6rUXVWZ0goLRmZ+8hv/RbGVWDmrbSrgYNM8rCfWvpg9GbLCCNjJ6ApY9atIlAr6g9My9ieToLRyUNOw==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@purista/harness/-/harness-1.7.1.tgz",
+			"integrity": "sha512-fKth2rJPTBs35Gs3xGomSfcI+v1MA7Uevf3Lft89uw4mRfuirhPE6G8ITRUJs+99Q0KBKontKYp7SV/7wd+edg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.41.1",
+				"@opentelemetry/semantic-conventions": "^1.43.0",
 				"yaml": "^2.9.0",
 				"zod": "^4.4.3"
 			},
@@ -4711,18 +4711,18 @@
 			}
 		},
 		"node_modules/@purista/harness-openai": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@purista/harness-openai/-/harness-openai-1.7.0.tgz",
-			"integrity": "sha512-NhepiQY7QvDWVi0C3tWrfVNkcOs3aXOILqnI0WziUBr1vbB4Q4lAl2OHajECZraNWviUilYplY8z0dfCt77Xqg==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@purista/harness-openai/-/harness-openai-1.7.1.tgz",
+			"integrity": "sha512-XBernegfXKqXU3izjlKMpTVxSHbqx7Uo6G1VexZF73YtUWz8sbLVvkKZ5xb5ElBauQkIldzin5HkXIpUDuAEpw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"openai": "^6.44.0"
+				"openai": "^6.48.0"
 			},
 			"engines": {
 				"node": ">=24.15.0"
 			},
 			"peerDependencies": {
-				"@purista/harness": "^1.7.0"
+				"@purista/harness": "^1.7.1"
 			}
 		},
 		"node_modules/@purista/hono-example": {
@@ -15104,9 +15104,9 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "6.45.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
-			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+			"version": "6.48.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
+			"integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
@@ -18900,7 +18900,7 @@
 				"@opentelemetry/resources": "^2.9.0",
 				"@opentelemetry/sdk-trace-node": "^2.9.0",
 				"@opentelemetry/semantic-conventions": "^1.43.0",
-				"@purista/harness": "^1.7.0",
+				"@purista/harness": "^1.7.1",
 				"@sodaru/yup-to-json-schema": "^2.0.1",
 				"@standard-schema/spec": "^1.1.0",
 				"code-block-writer": "^13.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
 		"@opentelemetry/resources": "^2.9.0",
 		"@opentelemetry/sdk-trace-node": "^2.9.0",
 		"@opentelemetry/semantic-conventions": "^1.43.0",
-		"@purista/harness": "^1.7.0",
+		"@purista/harness": "^1.7.1",
 		"@sodaru/yup-to-json-schema": "^2.0.1",
 		"@standard-schema/spec": "^1.1.0",
 		"code-block-writer": "^13.0.3",


### PR DESCRIPTION
## Summary

- Update @purista/harness in core to 1.7.1.
- Update @purista/harness-openai in the agent example to 1.7.1.
- Regenerate the lockfile, including the adapter's current OpenAI client and peer dependency updates.

## Why

PURISTA's agent runtime and its OpenAI example should consume the current AI Harness release together.

## Validation

- Confirmed both packages resolve to 1.7.1.
- Full unit and type-check suite: 639 tests passing.
- Full workspace build.
- Package-import smoke test.